### PR TITLE
iOS 5 support since UIProgressView no longer calls drawRect.

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -66,7 +66,13 @@ typedef enum {
 /**
  * A progress view for showing definite progress by filling up a circle (similar to the indicator for building in xcode).
  */
-@interface MBRoundProgressView : UIProgressView {}
+@interface MBRoundProgressView : UIView {
+    /** Store the progress **/
+    float progress;
+}
+
+/** Allow setting the progress in the same way as UIProgressView **/
+@property (nonatomic, assign) float progress;
 
 /**
  * Create a 37 by 37 pixel indicator. 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -599,7 +599,7 @@
 }
 
 - (void)setTransformForCurrentOrientation:(BOOL)animated {
-	UIDeviceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
 	NSInteger degrees = 0;
 	
 	if (UIInterfaceOrientationIsLandscape(orientation)) {
@@ -627,7 +627,9 @@
 @implementation MBRoundProgressView
 
 - (id)initWithDefaultSize {
-    return [super initWithFrame:CGRectMake(0.0f, 0.0f, 37.0f, 37.0f)];
+    self = [super initWithFrame:CGRectMake(0.0f, 0.0f, 37.0f, 37.0f)];
+    self.backgroundColor = [UIColor clearColor];
+    return self;
 }
 
 - (void)drawRect:(CGRect)rect {
@@ -652,6 +654,15 @@
     CGContextAddArc(context, x, y, (allRect.size.width - 4) / 2, -(PI / 2), (self.progress * 2 * PI) - PI / 2, 0);
     CGContextClosePath(context);
     CGContextFillPath(context);
+}
+
+-(float)progress {
+    return progress;
+}
+
+-(void)setProgress:(float)newProgress {
+    progress = newProgress;
+    [self setNeedsDisplay];
 }
 
 @end


### PR DESCRIPTION
Removed dependency on UIProgressView in the round progress view to support iOS5 and replaced UIDeviceOrientation that was being cast from a UIInterfaceOrientation.

It's a very simple change, just swapped UIProgressView for UIView, added a progress property and set the background colour to clear...
