### PR TITLE
Added hideDelayTime to complement graceTime and minShowTime.

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -67,12 +67,12 @@ typedef enum {
  * A progress view for showing definite progress by filling up a circle (similar to the indicator for building in xcode).
  */
 @interface MBRoundProgressView : UIView {
-    /** Store the progress **/
+    /** Store the progress */
     float progress;
 }
 
-/** Allow setting the progress in the same way as UIProgressView **/
-@property (nonatomic, assign) float progress;
+/** Allow setting the progress in the same way as UIProgressView */
+@property (assign) float progress;
 
 /**
  * Create a 37 by 37 pixel indicator. 
@@ -121,8 +121,9 @@ typedef enum {
 	BOOL taskInProgress;
 	float graceTime;
 	float minShowTime;
+    float hideDelayTime;
 	NSTimer *graceTimer;
-	NSTimer *minShowTimer;
+	NSTimer *hideTimer;
 	NSDate *showStarted;
 	
 	UIView *indicator;
@@ -262,6 +263,16 @@ typedef enum {
  * Defaults to 0 (no minimum show time).
  */
 @property (assign) float minShowTime;
+
+/**
+ * The time (in seconds) to wait after hide is called before
+ * the HUD should hide.
+ * Defaults to 0 (hides instantly)
+ *
+ * This is useful if you have finished your task but wish to change the status to, for example, 'Done'
+ * and display this to the user for a period of time
+ */
+@property (assign) float hideDelayTime;
 
 /**
  * Indicates that the executed operation is in progress. Needed for correct graceTime operation.


### PR DESCRIPTION
I wanted to display a "Completed" message at the end of my task and keep the HUD on screen for a short time such that the user could read it so I arrived at this.  Uses the same structure as the other two timers and I've renamed handleMinShowTimer to handleHideTimer since it now handles a delayed hide in both cases.  Care was taken to ensure that the minShowTime and graceTime timers still function exactly as they did before - This means that if the minShowTime is greater than the time spent already + the hideDelayTime the minShowTime will be used.

Usage:
hud.minShowTime = 1.0;
hud.hideDelayTime = 2.0;
[hud show];
[hud hide]; //hides 2 seconds later

I'll stop adding things now!
