### PR TITLE
Don't hide using animation if the HUD was never shown due to a grace time

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -553,7 +553,7 @@
 
 - (void)hideUsingAnimation:(BOOL)animated {
     // Fade out
-    if (animated) {
+    if (animated && showStarted) {
         [UIView beginAnimations:nil context:NULL];
         [UIView setAnimationDuration:0.30];
         [UIView setAnimationDelegate:self];


### PR DESCRIPTION
When a grace time is used and the HUD is never shown there should not be a fade out animation. If there is a fade out animation it will cause the HUD to be visible for a 0.3 seconds with alpha 0.0.2.
