### PR TITLE
Add method to hide and remove all the HUD subviews from a view

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -155,6 +155,18 @@ typedef enum {
  */
 + (int)hideAllHUDForView:(UIView *)view animated:(BOOL)animated;
 
+/**
+ * Stops the activity indicator in a HUD subview and change its text and detail text.
+ *
+ * @param view The view that is going to be searched for HUD subviews.
+ * @param title the text to set in the labelText.
+ * @param detail the text to set in the detailLabelText.
+ * @return YES if a HUD was found, its activity indicator was stopped and the text labels were changed.
+ *
+ * @see hideAllHUDForView:animated:
+ */
++ (BOOL)stopIndicatorInHUDForView:(UIView *)view settingText:(NSString *)title andDetailText:(NSString *)detail;
+
 /** 
  * A convenience constructor that initializes the HUD with the window's bounds. Calls the designated constructor with
  * window.bounds as the parameter.

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -235,6 +235,24 @@
 	return HUDCounter;
 };
 
++ (BOOL)stopIndicatorInHUDForView:(UIView *)view settingText:(NSString *)title andDetailText:(NSString *)detail {
+	UIView *viewToStop = nil;
+	for (UIView *v in [view subviews]) {
+		if ([v isKindOfClass:[MBProgressHUD class]]) {
+			viewToStop = v;
+		}
+	}
+	if (viewToStop != nil) {
+		MBProgressHUD *hud = (MBProgressHUD *)viewToStop;
+		[((UIActivityIndicatorView *)hud.indicator) stopAnimating];
+        [hud setLabelText:title];
+        [hud setDetailsLabelText:detail];
+		return YES;
+	} else {
+		return NO;
+	}
+}
+
 #pragma mark -
 #pragma mark Lifecycle methods
 


### PR DESCRIPTION
The already present `hideHUDForView:animated:` method hide and remove only one HUD found in the subviews (the last one). There are cases when more than one HUD can be added to a view (explicit add or just accidental fast user interactions): the added `hideAddHUDForView:animated:` method hides and removes all the HUD that have been previously added to a view.
