### PR TITLE
ARC for iOS4

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -1,6 +1,6 @@
 //
 //  MBProgressHUD.h
-//  Version 0.4
+//  Version 0.4.1 by Angel91
 //  Created by Matej Bukovinski on 2.4.09.
 //
 
@@ -27,6 +27,7 @@
 // THE SOFTWARE.
 
 #import <UIKit/UIKit.h>
+#import <objc/message.h>
 
 @protocol MBProgressHUDDelegate;
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -1,6 +1,6 @@
 //
 // MBProgressHUD.m
-// Version 0.4
+// Version 0.4.1 by Angel91
 // Created by Matej Bukovinski on 2.4.09.
 //
 
@@ -538,8 +538,11 @@
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 #endif	
     // Start executing the requested task
-    [targetForExecution performSelector:methodForExecution withObject:objectForExecution];
+    
+    //[targetForExecution performSelector:methodForExecution withObject:objectForExecution];
 	
+    objc_msgSend(objectForExecution, methodForExecution); //using this function you no longer see any memory leak warning
+    
     // Task completed, update view in main thread (note: view operations should
     // be done only in the main thread)
     [self performSelectorOnMainThread:@selector(cleanUp) withObject:nil waitUntilDone:NO];


### PR DESCRIPTION
My last pull request were not compatible with iOS4 ARC target.
This commit replace weak with unsafe_unretained, so it works now.

Sorry for the double pull request.

René
