### PR TITLE
Suppress clang warning of "performSelector may cause a leak because its ...

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -538,7 +538,10 @@
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 #endif	
     // Start executing the requested task
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
     [targetForExecution performSelector:methodForExecution withObject:objectForExecution];
+    #pragma clang diagnostic pop
 	
     // Task completed, update view in main thread (note: view operations should
     // be done only in the main thread)


### PR DESCRIPTION
...selector is unknown" with ARC. Assumes that your methodForExecution will not leak memory.
