### PR TITLE
handle ARC for iOS4

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -103,12 +103,6 @@ typedef enum {
 	UILabel *detailsLabel;
 	
 	float progress;
-	
-#if __has_feature(objc_arc)
-	id<MBProgressHUDDelegate> __weak delegate;
-#else
-	id<MBProgressHUDDelegate> delegate;
-#endif
     NSString *labelText;
 	NSString *detailsLabelText;
 	float opacity;
@@ -194,8 +188,10 @@ typedef enum {
  * delegate should conform to the MBProgressHUDDelegate protocol and implement the hudWasHidden method. The delegate
  * object will not be retained.
  */
-#if __has_feature(objc_arc)
+#if __has_feature(objc_arc_weak)
 @property (weak) id<MBProgressHUDDelegate> delegate;
+#elif __has_feature(objc_arc)
+@property (unsafe_unretained) id<MBProgressHUDDelegate> delegate;
 #else
 @property (assign) id<MBProgressHUDDelegate> delegate;
 #endif


### PR DESCRIPTION
iOS4 doesn't support weak, but unsafe_unretained doesn't support zeroing weak references, so add support for which ever is available.

Signed-off-by: Jerry Beers jerry@jerrybeers.com
