### PR TITLE
Double tap gesture recognizer

### DIFF
--- a/Demo/Classes/HudDemoViewController.m
+++ b/Demo/Classes/HudDemoViewController.m
@@ -222,8 +222,17 @@
 
 - (void)myMixedTask {
 	// Indeterminate mode
+	// Set the block but don't enable the gesture recognizer
+	[HUD setListenToDoubleTapGesture:NO];
+	[HUD setDoubleTapGestureBlock:^{
+		NSLog(@"Double tap!!");
+	}];
 	sleep(2);
 	// Switch to determinate mode
+	
+	// Enable the recognizer
+	[HUD setListenToDoubleTapGesture:YES];
+
 	HUD.mode = MBProgressHUDModeDeterminate;
 	HUD.labelText = @"Progress";
 	float progress = 0.0f;
@@ -233,6 +242,10 @@
 		HUD.progress = progress;
 		usleep(50000);
 	}
+	
+	// Disable the recognizer again
+	[HUD setListenToDoubleTapGesture:NO];
+
 	// Back to indeterminate mode
 	HUD.mode = MBProgressHUDModeIndeterminate;
 	HUD.labelText = @"Cleaning up";

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -341,6 +341,16 @@ typedef enum {
  */
 @property (assign, getter = isSquare) BOOL square;
 
+/**
+ * Set the HUD to listen to double tap gesture.
+ */
+@property (nonatomic, assign, setter = setListenToDoubleTapGesture:) BOOL listenToDoubleTapGesture;
+
+/**
+ * The block used when the gesture is recognized
+ */
+@property (assign) void (^doubleTapGestureBlock)(void);
+
 @end
 
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -50,6 +50,9 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @property (MB_STRONG) NSDate *showStarted;
 @property (assign) CGSize size;
 
+// Private
+@property (MB_STRONG) UITapGestureRecognizer *doubleTapRecognizer;
+
 @end
 
 
@@ -91,6 +94,9 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @synthesize detailsLabelText;
 @synthesize progress;
 @synthesize size;
+@synthesize listenToDoubleTapGesture = _listenToDoubleTapGesture;
+@synthesize doubleTapRecognizer = _doubleTapRecognizer;
+@synthesize doubleTapGestureBlock = _doubleTapGestureBlock;
 
 #pragma mark - Class methods
 
@@ -213,6 +219,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	[minShowTimer release];
 	[showStarted release];
 	[customView release];
+    [_doubleTapRecognizer release];
 	[super dealloc];
 #endif
 }
@@ -657,6 +664,41 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	if (animated) {
 		[UIView commitAnimations];
 	}
+}
+
+#pragma mark - Custom setters
+
+- (void) setListenToDoubleTapGesture:(BOOL) value {
+    _listenToDoubleTapGesture = value;
+    
+    if (value) {
+        
+        // If the tap recognizer is already allocated, than no need to create another one
+        if (_doubleTapRecognizer)
+            return;
+
+        UITapGestureRecognizer* tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
+        [tapRecognizer setNumberOfTapsRequired:2];
+        
+        [self addGestureRecognizer:tapRecognizer];
+        self.doubleTapRecognizer = tapRecognizer;
+
+#if !__has_feature(objc_arc)
+        [tapRecognizer release];
+#endif
+
+    } else {
+        [self removeGestureRecognizer:_doubleTapRecognizer];
+        self.doubleTapRecognizer = nil;
+    }
+}
+
+#pragma mark - Gesture recognizer methods
+
+- (void) handleTap: (UITapGestureRecognizer*)recognizer {
+    if (recognizer == _doubleTapRecognizer) {
+        _doubleTapGestureBlock();
+    }
 }
 
 @end


### PR DESCRIPTION
I've added a double tap gesture recogniser to the HUD. This can be especially useful when dealing with
cancel operations.

The HUD now exposes two properties: listenToDoubleTapGesture, which is a BOOL and doubleTapGestureBlock, which is the block that is going to be executed when the double tap gesture is hit.

I've updated the Demo as well (see mixed example to take a look at the GR in action).
