### PR TITLE
don't set alpha to 0 at beginning of fade out animation

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -274,7 +274,6 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 #pragma mark - Internal show & hide operations
 
 - (void)showUsingAnimation:(BOOL)animated {
-	self.alpha = 0.0f;
 	if (animated && animationType == MBProgressHUDAnimationZoom) {
 		self.transform = CGAffineTransformConcat(rotationTransform, CGAffineTransformMakeScale(1.5f, 1.5f));
 	}


### PR DESCRIPTION
I think there's no reason to set alpha to 0 here, and doing so causes the HUD to flicker if you make multiple calls to show, which ends up happening frequently in at least my code.
