### PR TITLE
Check iOS version when assigning label.textAlignment

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -442,9 +442,9 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	detailsLabel.font = self.detailsLabelFont;
 	detailsLabel.adjustsFontSizeToFitWidth = NO;
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
-    label.textAlignment = UITextAlignmentCenter;
+    detailsLabel.textAlignment = UITextAlignmentCenter;
 #else
-    label.textAlignment = NSTextAlignmentCenter;
+    detailsLabel.textAlignment = NSTextAlignmentCenter;
 #endif
 	detailsLabel.opaque = NO;
 	detailsLabel.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
UITextAlignmentCenter is deprecated as of iOS6.
Added version check to determine if NSTextAlignmentCenter should be used instead.
