### PR TITLE
HudForView: performance enhancement

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -127,7 +127,8 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 + (MBProgressHUD *)HUDForView:(UIView *)view {
 	NSArray *subviews = view.subviews;
 	Class hudClass = [MBProgressHUD class];
-	for (UIView *aView in subviews) {
+	for (NSUInteger i = subviews.count - 1; i >= 0; i--) {
+		UIView *aView = [subviews objectAtIndex:i];
 		if ([aView isKindOfClass:hudClass]) {
 			return (MBProgressHUD *)aView;
 		}


### PR DESCRIPTION
The `HUDForView:` method is currently iterating over _all_ of the view's subviews even if it finds the HUD before reaching the end of the array.  Also, since it starts looking for it at the beginning of the array of subviews, it is likely to iterate through the whole list before finding it.

Granted, a view should generally not have tons of subviews and iterating through the whole list every time generally shouldn't be a problem.  However, this protects against the scenario where someone does have lots of subviews and it improves performance for everyone.
