### PR TITLE
need visibility to setTransformForCurrentOrientation to use in certain circumstances

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -431,6 +431,18 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 @property (nonatomic, assign) float progress;
 
+/**
+ * Indicator progress color.
+ * Defaults to white [UIColor whiteColor]
+ */
+@property (nonatomic, MB_STRONG) UIColor *progressTintColor;
+
+/**
+ * Indicator background (non-progress) color.
+ * Defaults to translucent white (alpha 0.1)
+ */
+@property (nonatomic, MB_STRONG) UIColor *backgroundTintColor;
+
 /*
  * Display mode - NO = round or YES = annular. Defaults to round.
  */

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -282,7 +282,6 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 #pragma mark - Internal show & hide operations
 
 - (void)showUsingAnimation:(BOOL)animated {
-	self.alpha = 0.0f;
 	if (animated && animationType == MBProgressHUDAnimationZoomIn) {
 		self.transform = CGAffineTransformConcat(rotationTransform, CGAffineTransformMakeScale(0.5f, 0.5f));
 	} else if (animated && animationType == MBProgressHUDAnimationZoomOut) {


### PR DESCRIPTION
discovered that HUDs were being displayed sideways or upside-down when
using the .view.window of a popped UINavigationController as the root
for a HUD view when returning.  if using the current view, the HUD would
not appear.  by using this call under that circumstance, the problem was
solved … so made it public.