### PR TITLE
Height/width calculation fix

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -494,7 +494,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	CGRect bounds = self.bounds;
 	
 	// Determine the total widt and height needed
-	CGFloat maxWidth = bounds.size.width - 4 * margin;
+	CGFloat maxWidth = bounds.size.width - 2 * margin;
 	CGSize totalSize = CGSizeZero;
 	
 	CGRect indicatorF = indicator.bounds;
@@ -510,7 +510,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		totalSize.height += kPadding;
 	}
 
-	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin; 
+	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 2 * margin; 
 	CGSize maxSize = CGSizeMake(maxWidth, remainingHeight);
 	CGSize detailsLabelSize = [detailsLabel.text sizeWithFont:detailsLabel.font 
 								constrainedToSize:maxSize lineBreakMode:detailsLabel.lineBreakMode];


### PR DESCRIPTION
We should only be subtracting `margin * 2` not `margin * 4` in a couple places.  Discovered this while creating an indeterminate HUD in a view where height > width and I'd set `hud.square = YES`.  Result was a tall skinny HUD instead of a square one.