### PR TITLE
Cancel delayed hide and show requests when showing and hiding

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -208,6 +208,10 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * Hide the HUD after a delay. This still calls the hudWasHidden: delegate. This is the counterpart of the show: method. Use it to
  * hide the HUD when your task completes.
  *
+ * To avoid conflicts, any call to show the HUD will cause an outstanding delayed hide to be invalidated. This means that
+ * hide:afterDelay: must be called *after* the HUD is shown. The HUD may be shown again (for example, with different text)
+ * without interference from the previous delayed hide.
+ *
  * @param animated If set to YES the HUD will disappear using the current animationType. If set to NO the HUD will not use
  * animations while disappearing.
  * @param delay Delay in secons until the HUD is hidden.
@@ -360,7 +364,10 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 /**
  * The minimum time (in seconds) that the HUD is shown. 
- * This avoids the problem of the HUD being shown and than instantly hidden.
+ * This avoids the problem of the HUD being shown and then instantly hidden.
+ * Showing the same HUD multiple times (for example, with different text) will
+ * cause the timer to be reset such that the HUD remains visible for the
+ * specified minimum time after the last show call.
  * Defaults to 0 (no minimum show time).
  */
 @property (assign) float minShowTime;


### PR DESCRIPTION
There was previously no way to cancel the timers and delayed invocations established by `graceTime`, `minShowTime`, and `hide:afterDelay:`. This was problematic when showing a number of HUD messages in series, as the `minShowTime` of the first message determined when the HUD would be hidden. The expected behavior, as I see it, would be to reset the effects of `minShowTime` each time a show method is called.

I applied the same logic to `hide:afterDelay:` and `graceTime`. The case for `graceTime` is a bit more obscure as you would have to show a message with a `graceTime`, show another message without a `graceTime`, then hide the HUD before the `graceTime` has elapsed. In this scenario, the HUD would pop up again after the timer elapsed.

`[self.graceTimer invalidate];` was chosen over a more verbose option simply because it will be a no-op when `graceTimer` is nil and has less overhead from method calls than the following:
```obj-c
if (self.graceTimer) {
    [self.graceTimer invalidate];
    self.graceTimer = nil;
}
```

One regression issue is that this would have previously worked:
```obj-c
[hud hide:YES afterDelay:3.0];
[hud show:YES];
```
while now the hide calls must follow the show calls:
```obj-c
[hud show:YES];
[hud hide:YES afterDelay:3.0];
```

This is an alternative to #106 which seemed to be addressing a similar issue.