### PR TITLE
Fixed example in Readme

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -72,7 +72,7 @@ hud.labelText = @"Loading";
 [self doSomethingInBackgroundWithProgressCallback:^(float progress) {
 	hud.progress = progress;
 } completionCallback:^{
-	[MBProgressHUD hideHUDForView:self.view animated:YES];
+	[hud hide:YES];
 }];
 ```
 


### PR DESCRIPTION
Properly hides the HUD at completion.
