### PR TITLE
MBLabelAlignmentCenter risk of being defined multiple times

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -74,17 +74,9 @@ typedef enum {
 #endif
 #endif
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
-	#define MBLabelAlignmentCenter NSTextAlignmentCenter
-#else
-	#define MBLabelAlignmentCenter UITextAlignmentCenter
-#endif
-
 #if NS_BLOCKS_AVAILABLE
 typedef void (^MBProgressHUDCompletionBlock)();
 #endif
-
-
 
 
 /** 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -17,6 +17,12 @@
 	#define MB_RETAIN(exp) [exp retain]
 #endif
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+    #define MBLabelAlignmentCenter NSTextAlignmentCenter
+#else
+    #define MBLabelAlignmentCenter UITextAlignmentCenter
+#endif
+
 
 static const CGFloat kPadding = 4.f;
 static const CGFloat kLabelFontSize = 16.f;


### PR DESCRIPTION
Declaration doesn't need to be in header, moved into implementation file.
