### PR TITLE
Improved subclassing

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -56,6 +56,14 @@ typedef enum {
 } MBProgressHUDAnimation;
 
 
+#ifndef MB_INSTANCETYPE
+    #if __has_feature(objc_instancetype)
+        #define MB_INSTANCETYPE instancetype
+    #else
+        #define MB_INSTANCETYPE id
+    #endif
+#endif
+
 #ifndef MB_STRONG
 #if __has_feature(objc_arc)
 	#define MB_STRONG strong
@@ -119,7 +127,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * @see hideHUDForView:animated:
  * @see animationType
  */
-+ (instancetype)showHUDAddedTo:(UIView *)view animated:(BOOL)animated;
++ (MB_INSTANCETYPE)showHUDAddedTo:(UIView *)view animated:(BOOL)animated;
 
 /**
  * Finds the top-most HUD subview and hides it. The counterpart to this method is showHUDAddedTo:animated:.
@@ -153,7 +161,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * @param view The view that is going to be searched.
  * @return A reference to the last HUD subview discovered.
  */
-+ (instancetype)HUDForView:(UIView *)view;
++ (MB_INSTANCETYPE)HUDForView:(UIView *)view;
 
 /**
  * Finds all HUD subviews and returns them.

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -98,7 +98,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 #pragma mark - Class methods
 
-+ (instancetype)showHUDAddedTo:(UIView *)view animated:(BOOL)animated {
++ (MB_INSTANCETYPE)showHUDAddedTo:(UIView *)view animated:(BOOL)animated {
 	MBProgressHUD *hud = [[self alloc] initWithView:view];
 	[view addSubview:hud];
 	[hud show:animated];
@@ -124,7 +124,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	return [huds count];
 }
 
-+ (instancetype)HUDForView:(UIView *)view {
++ (MB_INSTANCETYPE)HUDForView:(UIView *)view {
 	NSEnumerator *subviewsEnum = [view.subviews reverseObjectEnumerator];
 	for (UIView *subview in subviewsEnum) {
 		if ([subview isKindOfClass:self]) {


### PR DESCRIPTION
Replaced fix class type through instancetype and used self in static methods instead of fixed class reference to enable improved subclassing.
This will break compatiblity with older compilers, but if needed we could define a macro to use either id or instancetype.
