### PR TITLE
Quiet warning in non-ARC mode

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -911,7 +911,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	[_lineColor release];
 	[_progressColor release];
 	[_progressRemainingColor release];
-	
+	[super dealloc];	
 #endif
 	
 }


### PR DESCRIPTION
Adds a [super dealloc] to FlatProgressView's -dealloc, which currently warns in non-ARC mode.
