### PR TITLE
Fixed a possible memory leak	

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -416,7 +416,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 - (void)cleanUp {
 	taskInProgress = NO;
-    [indicator removeFromSuperview];
+	[indicator removeFromSuperview];
 	self.indicator = nil;
 #if !__has_feature(objc_arc)
 	[targetForExecution release];


### PR DESCRIPTION
`cleanUp` set `self.indicator = nil` without remove `self.indicator` from view hierarchy. It will create memory leaks if the MBProgressHud is reused several times.
