### PR TITLE
- fix a possible memory leak

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -416,7 +416,6 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 - (void)cleanUp {
 	taskInProgress = NO;
-	self.indicator = nil;
 #if !__has_feature(objc_arc)
 	[targetForExecution release];
 	[objectForExecution release];


### PR DESCRIPTION
`cleanUp` set `self.indicator = nil` without remove `self.indicator` from the view hierarchy. It will introduce memory leaks if the MBProgressHud is reused several times with different indicators. 
By removing  `self.indicator = nil`, the indicator can be correctly removed from the view hierarchy when the MBProgressHud is assigned with a new indicator.
