### PR TITLE
Set ONLY_ACTIVE_ARC=NO in debug build configuration

### DIFF
--- a/MBProgressHUD.xcodeproj/project.pbxproj
+++ b/MBProgressHUD.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 				DSTROOT = /tmp/MBProgressHUD.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MBProgressHUD-Prefix.pch";
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
This allows projects that include MBProgressHUD as
a dependent target to still build and deploy on
the iPhone 5s when building the host project in
Debug build configuration.