### PR TITLE
When calling multiple show: and hide: too fast, some of the HUDs can get stuck

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -131,11 +131,13 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 }
 
 + (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated {
-	MBProgressHUD *hud = [self HUDForView:view];
-	if (hud != nil) {
-		hud.removeFromSuperViewOnHide = YES;
-		[hud hide:animated];
-		return YES;
+	NSArray *huds = [MBProgressHUD allHUDsForView:view];
+	for (MBProgressHUD *hud in huds) {
+		if (hud != nil && !hud.removeFromSuperViewOnHide) {
+			hud.removeFromSuperViewOnHide = YES;
+			[hud hide:animated];
+			return YES;
+		}
 	}
 	return NO;
 }


### PR DESCRIPTION
The problem is, when hiding, we only hide the first HUD in the list, but that one can be in the process of being deleted, but not finished yet (because it's animating or any other cause). My fix gets the first non-hiding HUD and uses that one instead.