### PR TITLE
Added a drop in category with self-contained convenience constructors [MBProgressHUD displayGlobalHUD] and [MBProgressHUD dismissGlobalHUD]

### DIFF
--- a/Demo/Classes/HudDemoViewController.h
+++ b/Demo/Classes/HudDemoViewController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import "MBProgressHUD.h"
+#import "MBProgressHUD+GlobalHUD.h"
 
 @interface HudDemoViewController : UIViewController <MBProgressHUDDelegate> {
 	MBProgressHUD *HUD;

--- a/Demo/Classes/HudDemoViewController.m
+++ b/Demo/Classes/HudDemoViewController.m
@@ -302,6 +302,20 @@
 }
 
 #pragma mark -
+#pragma mark Global HUD
+
+- (IBAction)displayGlobalHUD:(id)sender
+{
+	[MBProgressHUD displayGlobalHUD];
+	
+	double delayInSeconds = 2.0;
+	dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+	dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+		[MBProgressHUD dismissGlobalHUD];
+	});
+}
+
+#pragma mark -
 #pragma mark MBProgressHUDDelegate methods
 
 - (void)hudWasHidden:(MBProgressHUD *)hud {

--- a/Demo/Classes/MBProgressHUD+GlobalHUD.h
+++ b/Demo/Classes/MBProgressHUD+GlobalHUD.h
@@ -1,0 +1,35 @@
+//
+//  MBProgressHUD+GlobalHUD.h
+//  Remind101
+//
+//  Created by Rex Fenley on 11/9/13.
+//
+
+// This code is distributed under the terms and conditions of the MIT license.
+
+// Copyright (c) 2013 Remind101, Rex Fenley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MBProgressHUD.h"
+
+@interface MBProgressHUD (GlobalHUD) <MBProgressHUDDelegate>
++ (void)displayGlobalHUD;
++ (void)dismissGlobalHUD;
+@end

--- a/Demo/Classes/MBProgressHUD+GlobalHUD.m
+++ b/Demo/Classes/MBProgressHUD+GlobalHUD.m
@@ -1,0 +1,103 @@
+//
+//  MBProgressHUD+GlobalHUD.m
+//  Remind101
+//
+//  Created by Rex Fenley on 11/9/13.
+//
+
+// This code is distributed under the terms and conditions of the MIT license.
+
+// Copyright (c) 2013 Remind101, Rex Fenley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MBProgressHUD+GlobalHUD.h"
+
+#import <objc/runtime.h>
+
+@implementation MBProgressHUD (GlobalHUD)
+
+static void * const kHUDCountStorageKey = (void *)&kHUDCountStorageKey;
+static MBProgressHUD * globalHUD;
+
++ (void)renewGlobalHUD
+{
+    NSArray *windows = [[UIApplication sharedApplication] windows];
+    UIWindow *window = [windows lastObject];
+    
+    CGFloat currentTopWindowLevel = 1500;
+    
+    if (window.windowLevel > currentTopWindowLevel) {
+        // For reference, 1996-2000 is UIAlertView. Unfortunately we don't have safe access to those values.
+        // Make sure we're not attaching to an alert view that's about to dismiss.
+        for (NSInteger i = windows.count - 1; i >= 0; i--) {
+            window = windows[i];
+            if (window.windowLevel <= currentTopWindowLevel) break;
+        }
+    }
+    
+    globalHUD = [[MBProgressHUD alloc] initWithWindow:window];
+    [window addSubview:globalHUD];
+    
+    globalHUD.delegate = globalHUD;
+}
+
+// NSInteger protects against over dismissing.
+- (NSInteger)hudCount
+{
+    NSNumber *hudCount = objc_getAssociatedObject(self, kHUDCountStorageKey);
+    
+    if (hudCount) return [hudCount integerValue];
+    else return 0;
+}
+
+- (void)setHudCount:(NSInteger)hudCount
+{
+    NSNumber *hudCountObject = [NSNumber numberWithInteger:hudCount];
+    objc_setAssociatedObject(self, kHUDCountStorageKey, hudCountObject, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+#pragma mark - Displaying/Dismissing
+
++ (void)displayGlobalHUD
+{
+    if (!globalHUD || globalHUD.hudCount == 0) {
+        [MBProgressHUD renewGlobalHUD];
+        [globalHUD show:YES];
+    }
+    globalHUD.hudCount += 1;
+}
+
++ (void)dismissGlobalHUD
+{
+    globalHUD.hudCount -= 1;
+    if (globalHUD.hudCount == 0) {
+        [globalHUD hide:NO];
+    }
+}
+
+#pragma mark - MBProgressHUDDelegate methods
+
+- (void)hudWasHidden:(MBProgressHUD *)hud
+{
+	// Remove HUD from screen when the HUD was hidded
+	[hud removeFromSuperview];
+}
+
+@end

--- a/Demo/HudDemo.xcodeproj/project.pbxproj
+++ b/Demo/HudDemo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		28D7ACF80DDB3853001CB0EB /* HudDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28D7ACF70DDB3853001CB0EB /* HudDemoViewController.m */; };
+		CDCBE85F18A5C4C800AB73A1 /* MBProgressHUD+GlobalHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCBE85E18A5C4C800AB73A1 /* MBProgressHUD+GlobalHUD.m */; };
 		D21D40801611CF6C005FCE55 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D21D407F1611CF6C005FCE55 /* Default-568h@2x.png */; };
 		D22F7D810F85241C00550BB3 /* MBProgressHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = D22F7D800F85241C00550BB3 /* MBProgressHUD.m */; };
 		D24A23051780ADCD0020310A /* Icon-Small.png in Resources */ = {isa = PBXBuildFile; fileRef = D22568E61780AA77008D5939 /* Icon-Small.png */; };
@@ -41,6 +42,8 @@
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* HudDemo_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HudDemo_Prefix.pch; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CDCBE85D18A5C4C800AB73A1 /* MBProgressHUD+GlobalHUD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MBProgressHUD+GlobalHUD.h"; sourceTree = "<group>"; };
+		CDCBE85E18A5C4C800AB73A1 /* MBProgressHUD+GlobalHUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MBProgressHUD+GlobalHUD.m"; sourceTree = "<group>"; };
 		D21D407F1611CF6C005FCE55 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "Images/Default-568h@2x.png"; sourceTree = "<group>"; };
 		D22568E31780A913008D5939 /* Default-iOS7-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-iOS7-568h@2x.png"; path = "Images/Default-iOS7-568h@2x.png"; sourceTree = "<group>"; };
 		D22568E41780A913008D5939 /* Default-iOS7@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-iOS7@2x.png"; path = "Images/Default-iOS7@2x.png"; sourceTree = "<group>"; };
@@ -79,6 +82,8 @@
 			children = (
 				D22F7D7F0F85241C00550BB3 /* MBProgressHUD.h */,
 				D22F7D800F85241C00550BB3 /* MBProgressHUD.m */,
+				CDCBE85D18A5C4C800AB73A1 /* MBProgressHUD+GlobalHUD.h */,
+				CDCBE85E18A5C4C800AB73A1 /* MBProgressHUD+GlobalHUD.m */,
 				1D3623240D0F684500981E51 /* HudDemoAppDelegate.h */,
 				1D3623250D0F684500981E51 /* HudDemoAppDelegate.m */,
 				28D7ACF60DDB3853001CB0EB /* HudDemoViewController.h */,
@@ -244,6 +249,7 @@
 			files = (
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
 				1D3623260D0F684500981E51 /* HudDemoAppDelegate.m in Sources */,
+				CDCBE85F18A5C4C800AB73A1 /* MBProgressHUD+GlobalHUD.m in Sources */,
 				28D7ACF80DDB3853001CB0EB /* HudDemoViewController.m in Sources */,
 				D22F7D810F85241C00550BB3 /* MBProgressHUD.m in Sources */,
 			);

--- a/Demo/en.lproj/HudDemoViewController.xib
+++ b/Demo/en.lproj/HudDemoViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4457.9" systemVersion="12E55" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment version="528" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3682.9"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HudDemoViewController">
@@ -12,11 +12,11 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="52">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="697"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="743"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="54">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="697"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="743"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <subviews>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8">
@@ -24,7 +24,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Simple indeterminate progress">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -39,7 +38,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="With label">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -54,7 +52,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="With details label">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="disabled" title="With details label"/>
@@ -71,7 +68,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Determinate mode">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -86,7 +82,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Annular determinate mode">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -101,7 +96,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Bar determinate mode">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -116,7 +110,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Mode switching">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -131,7 +124,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Using blocks">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -146,7 +138,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="On Window">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -161,7 +152,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="NSURLConnection">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -176,7 +166,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Custom view">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -191,7 +180,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Dim background">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -206,7 +194,6 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Text only">
-                                <color key="titleColor" red="0.19607843" green="0.30980393000000001" blue="0.52156866000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <state key="highlighted">
@@ -221,14 +208,21 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                             <state key="normal" title="Colored">
-                                <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <connections>
                                 <action selector="showWithColor:" destination="-1" eventType="touchUpInside" id="116"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="o2Z-UY-Ntr">
+                            <rect key="frame" x="20" y="686" width="280" height="37"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                            <state key="normal" title="Display Global HUD">
+                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                            </state>
+                            <connections>
+                                <action selector="displayGlobalHUD:" destination="-1" eventType="touchUpInside" id="HPT-89-g4v"/>
                             </connections>
                         </button>
                     </subviews>

--- a/MBProgressHUD+GlobalHUD.h
+++ b/MBProgressHUD+GlobalHUD.h
@@ -1,0 +1,31 @@
+//
+//  MBProgressHUD+GlobalHUD.h
+//  Remind101
+//
+//  Created by Rex Fenley on 11/9/13.
+//  Copyright (c) 2013 Remind101. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MBProgressHUD.h"
+
+@interface MBProgressHUD (GlobalHUD) <MBProgressHUDDelegate>
++ (void)displayGlobalHUD;
++ (void)dismissGlobalHUD;
+@end

--- a/MBProgressHUD+GlobalHUD.m
+++ b/MBProgressHUD+GlobalHUD.m
@@ -1,0 +1,99 @@
+//
+//  MBProgressHUD+GlobalHUD.m
+//  Remind101
+//
+//  Created by Rex Fenley on 11/9/13.
+//  Copyright (c) 2013 Remind101. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MBProgressHUD+GlobalHUD.h"
+
+#import <objc/runtime.h>
+
+@implementation MBProgressHUD (GlobalHUD)
+
+static void * const kHUDCountStorageKey = (void *)&kHUDCountStorageKey;
+static MBProgressHUD * globalHUD;
+
++ (void)renewGlobalHUD
+{
+    NSArray *windows = [[UIApplication sharedApplication] windows];
+    UIWindow *window = [windows lastObject];
+    
+    CGFloat currentTopWindowLevel = 1500;
+    
+    if (window.windowLevel > currentTopWindowLevel) {
+        // For reference, 1996-2000 is UIAlertView. Unfortunately we don't have safe access to those values.
+        // Make sure we're not attaching to an alert view that's about to dismiss.
+        for (NSInteger i = windows.count - 1; i >= 0; i--) {
+            window = windows[i];
+            if (window.windowLevel <= currentTopWindowLevel) break;
+        }
+    }
+    
+    globalHUD = [[MBProgressHUD alloc] initWithWindow:window];
+    [window addSubview:globalHUD];
+    
+    globalHUD.delegate = globalHUD;
+}
+
+// NSInteger protects against over dismissing.
+- (NSInteger)hudCount
+{
+    NSNumber *hudCount = objc_getAssociatedObject(self, kHUDCountStorageKey);
+    
+    if (hudCount) return [hudCount integerValue];
+    else return 0;
+}
+
+- (void)setHudCount:(NSInteger)hudCount
+{
+    NSNumber *hudCountObject = [NSNumber numberWithInteger:hudCount];
+    objc_setAssociatedObject(self, kHUDCountStorageKey, hudCountObject, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+#pragma mark - Displaying/Dismissing
+
++ (void)displayGlobalHUD
+{
+    if (!globalHUD || globalHUD.hudCount == 0) {
+        [MBProgressHUD renewGlobalHUD];
+        [globalHUD show:YES];
+    }
+    globalHUD.hudCount += 1;
+}
+
++ (void)dismissGlobalHUD
+{
+    globalHUD.hudCount -= 1;
+    if (globalHUD.hudCount == 0) {
+        [globalHUD hide:NO];
+    }
+}
+
+#pragma mark - MBProgressHUDDelegate methods
+
+- (void)hudWasHidden:(MBProgressHUD *)hud
+{
+	// Remove HUD from screen when the HUD was hidded
+	[hud removeFromSuperview];
+}
+
+@end

--- a/MBProgressHUD.xcodeproj/project.pbxproj
+++ b/MBProgressHUD.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1315DD7617804CBC0032507D /* MBProgressHUD.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D286A7511518C70F00E13FB8 /* MBProgressHUD.h */; };
+		CDCBE85B18A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCBE85A18A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.m */; };
+		CDCBE85C18A5C39300AB73A1 /* MBProgressHUD+GlobalHUD.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CDCBE85918A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.h */; };
 		D286A74D1518C70F00E13FB8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D286A74C1518C70F00E13FB8 /* Foundation.framework */; };
 		D286A7531518C70F00E13FB8 /* MBProgressHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = D286A7521518C70F00E13FB8 /* MBProgressHUD.m */; };
 		D286A75E1518C89600E13FB8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D286A75D1518C89600E13FB8 /* UIKit.framework */; };
@@ -21,6 +23,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				CDCBE85C18A5C39300AB73A1 /* MBProgressHUD+GlobalHUD.h in CopyFiles */,
 				1315DD7617804CBC0032507D /* MBProgressHUD.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -29,6 +32,8 @@
 
 /* Begin PBXFileReference section */
 		1315DD73178045000032507D /* MBProgressHUD-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MBProgressHUD-Prefix.pch"; sourceTree = SOURCE_ROOT; };
+		CDCBE85918A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MBProgressHUD+GlobalHUD.h"; sourceTree = SOURCE_ROOT; };
+		CDCBE85A18A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MBProgressHUD+GlobalHUD.m"; sourceTree = SOURCE_ROOT; };
 		D286A7491518C70F00E13FB8 /* libMBProgressHUD.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMBProgressHUD.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D286A74C1518C70F00E13FB8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D286A7511518C70F00E13FB8 /* MBProgressHUD.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBProgressHUD.h; sourceTree = SOURCE_ROOT; };
@@ -91,6 +96,8 @@
 			children = (
 				D286A7511518C70F00E13FB8 /* MBProgressHUD.h */,
 				D286A7521518C70F00E13FB8 /* MBProgressHUD.m */,
+				CDCBE85918A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.h */,
+				CDCBE85A18A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.m */,
 				1315DD72178044770032507D /* Supporting Files */,
 			);
 			path = MBProgressHUD;
@@ -148,6 +155,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDCBE85B18A5C32900AB73A1 /* MBProgressHUD+GlobalHUD.m in Sources */,
 				D286A7531518C70F00E13FB8 /* MBProgressHUD.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Added a drop in category `MBProgressHUD+GlobalHUD`. It's completely self contained and respects the `UIAlertView` window level so that your `UIAlertView`s are never blocked.

All the user needs to do is call `[MBProgressHUD displayGlobalHUD]` and `[MBProgressHUD dismissGlobalHUD]` when necessary.

It uses a reference count and when the count > 0 the HUD displays, this means that someone could drop these calls in one place that uses async dispatching (such as in networking code) and never worry about the HUD displaying for too long or too short!

As long as the calls are balanced everything works out perfect.

I also added it to the Demo project :smile:
