### PR TITLE
Hidding huds that are nor being hidden at the moment

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -72,6 +72,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @property (atomic, MB_STRONG) NSTimer *minShowTimer;
 @property (atomic, MB_STRONG) NSDate *showStarted;
 @property (atomic, assign) CGSize size;
+@property (atomic, assign) BOOL isGoingToBeHidden;
 
 @end
 
@@ -117,6 +118,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @synthesize detailsLabelText;
 @synthesize progress;
 @synthesize size;
+@synthesize isGoingToBeHidden;
 #if NS_BLOCKS_AVAILABLE
 @synthesize completionBlock;
 #endif
@@ -152,7 +154,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 + (MB_INSTANCETYPE)HUDForView:(UIView *)view {
 	NSEnumerator *subviewsEnum = [view.subviews reverseObjectEnumerator];
 	for (UIView *subview in subviewsEnum) {
-		if ([subview isKindOfClass:self]) {
+		if ([subview isKindOfClass:self] && !((MBProgressHUD*)subview).isGoingToBeHidden) {
 			return (MBProgressHUD *)subview;
 		}
 	}
@@ -263,6 +265,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 }
 
 - (void)hide:(BOOL)animated {
+    isGoingToBeHidden = YES;
 	useAnimation = animated;
 	// If the minShow time is set, calculate how long the hud was shown,
 	// and pospone the hiding operation if necessary


### PR DESCRIPTION
Related: https://github.com/jdg/MBProgressHUD/pull/188

I will describe it again.
The key problem occurs when we in the same view call several HUDs that handle different processes.
But when we call the `hideHUDForView:animated:` and set `animated:YES`, we have a following conflict:
```
showing hud presync 0x9aa7980
showing hud dash 0x8dee690
hiding hud 0x8dee690
hiding hud 0x8dee690
REMOVED 0x9aa7980
REMOVED 0x8dee690
```

As you can see the HUD actually gets removed from parentView too late, which makes `hideHUDForView:animated:` work on the same HUD.

If a HUD is in the "removing" process, we don't care about it anymore, therefore it doesn't even need to counts as a present HUD for the view.