### PR TITLE
Expose HUD bezel size as read only public property

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -419,6 +419,13 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 @property (assign) CGSize minSize;
 
+
+/**
+ * The actual size of the HUD bezel.
+ */
+@property (atomic, assign, readonly) CGSize size;
+
+
 /**
  * Force the HUD dimensions to be equal if possible. 
  */

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -71,7 +71,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @property (atomic, MB_STRONG) NSTimer *graceTimer;
 @property (atomic, MB_STRONG) NSTimer *minShowTimer;
 @property (atomic, MB_STRONG) NSDate *showStarted;
-@property (atomic, assign) CGSize size;
+
 
 @end
 
@@ -600,7 +600,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		totalSize.height = minSize.height;
 	}
 	
-	self.size = totalSize;
+	size = totalSize;
 }
 
 #pragma mark BG Drawing


### PR DESCRIPTION
We have a situation where we want to add a tap gesture recognizer to
the HUD for “tap to cancel” behavior. We want to ignore the tap gesture
if the tap did not occur within the bezel region of the HUD. By
exposing the ‘size’ property, we can determine if the tap location is
within the rectangle of the bezel.

Here is an example of code that processes a tap event that was added to
the HUD

```
-(void)tapReceived:(UITapGestureRecognizer *)recognizer{
    CGPoint loc = [recognizer locationInView:progress];

    CGFloat w = progress.size.width;
    CGFloat h = progress.size.height;
    CGFloat x = progress.center.x - w/2;
    CGFloat y = progress.center.y - h/2;
    CGRect progressRect = CGRectMake(x, y, w, h);

    //if the tap was within the HUD bezel, then react to it, ignore it
otherwise
    if(CGRectContainsPoint(progressRect, loc)){
        //do any actions here (cancel operation for example)
        [progress hide:YES];
    }else{
        //the tap location was not in the bezel region of the HUD so
igore it.
        return;
    }
}
```
