### PR TITLE
Added Additional Positioning Options

### DIFF
--- a/Demo/Classes/HudDemoViewController.m
+++ b/Demo/Classes/HudDemoViewController.m
@@ -25,6 +25,8 @@
 }
 
 @property (retain, nonatomic) IBOutletCollection(UIButton) NSArray *buttons;
+@property (retain, nonatomic) IBOutlet UISegmentedControl *verticalSegmentedControl;
+@property (retain, nonatomic) IBOutlet UISegmentedControl *horizontalSegmentedControl;
 
 @end
 
@@ -57,10 +59,31 @@
 
 - (void)dealloc {
 	[_buttons release];
+	[_verticalSegmentedControl release];
+	[_horizontalSegmentedControl release];
 	[super dealloc];
 }
 
 #pragma mark - Actions
+
+- (MBProgressHUDPosition)getPosition {
+	MBProgressHUDPosition position = 0;
+	if (self.horizontalSegmentedControl.selectedSegmentIndex == 0) {
+		position |= MBProgressHUDPositionLeft;
+	} else if (self.horizontalSegmentedControl.selectedSegmentIndex == 2) {
+		position |= MBProgressHUDPositionRight;
+	} else {
+		position |= MBProgressHUDPositionCenterHorizontal;
+	}
+	if (self.verticalSegmentedControl.selectedSegmentIndex == 0) {
+		position |= MBProgressHUDPositionTop;
+	} else if (self.verticalSegmentedControl.selectedSegmentIndex == 2) {
+		position |= MBProgressHUDPositionBottom;
+	} else {
+		position |= MBProgressHUDPositionCenterVertical;
+	}
+	return position;
+}
 
 - (IBAction)showSimple:(id)sender {
 	// The hud will dispable all input on the view (use the higest view possible in the view hierarchy)
@@ -69,6 +92,7 @@
 	
 	// Regiser for HUD callbacks so we can remove it from the window at the right time
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	
 	// Show the HUD while the provided method executes in a new thread
 	[HUD showWhileExecuting:@selector(myTask) onTarget:self withObject:nil animated:YES];
@@ -80,6 +104,7 @@
 	[self.navigationController.view addSubview:HUD];
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	HUD.labelText = @"Loading";
 	
 	[HUD showWhileExecuting:@selector(myTask) onTarget:self withObject:nil animated:YES];
@@ -91,6 +116,7 @@
 	[self.navigationController.view addSubview:HUD];
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	HUD.labelText = @"Loading";
 	HUD.detailsLabelText = @"updating data";
 	HUD.square = YES;
@@ -107,6 +133,7 @@
 	HUD.mode = MBProgressHUDModeDeterminate;
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	HUD.labelText = @"Loading";
 	
 	// myProgressTask uses the HUD instance to update progress
@@ -121,6 +148,7 @@
 	HUD.mode = MBProgressHUDModeAnnularDeterminate;
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	HUD.labelText = @"Loading";
 	
 	// myProgressTask uses the HUD instance to update progress
@@ -136,6 +164,7 @@
 	HUD.mode = MBProgressHUDModeDeterminateHorizontalBar;
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	
 	// myProgressTask uses the HUD instance to update progress
 	[HUD showWhileExecuting:@selector(myProgressTask) onTarget:self withObject:nil animated:YES];
@@ -154,6 +183,7 @@
 	HUD.mode = MBProgressHUDModeCustomView;
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	HUD.labelText = @"Completed";
 	
 	[HUD show:YES];
@@ -166,6 +196,7 @@
 	[self.navigationController.view addSubview:HUD];
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	HUD.labelText = @"Connecting";
 	HUD.minSize = CGSizeMake(135.f, 135.f);
 	
@@ -193,6 +224,7 @@
 	[self.view.window addSubview:HUD];
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	HUD.labelText = @"Loading";
 	
 	[HUD showWhileExecuting:@selector(myTask) onTarget:self withObject:nil animated:YES];
@@ -208,6 +240,7 @@
 	
 	HUD = [[MBProgressHUD showHUDAddedTo:self.navigationController.view animated:YES] retain];
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 }
 
 
@@ -220,6 +253,7 @@
 	
 	// Regiser for HUD callbacks so we can remove it from the window at the right time
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	
 	// Show the HUD while the provided method executes in a new thread
 	[HUD showWhileExecuting:@selector(myTask) onTarget:self withObject:nil animated:YES];
@@ -231,6 +265,7 @@
 	
 	// Configure for text only and offset down
 	hud.mode = MBProgressHUDModeText;
+	hud.position = [self getPosition];
 	hud.labelText = @"Some message...";
 	hud.margin = 10.f;
 	hud.removeFromSuperViewOnHide = YES;
@@ -246,6 +281,7 @@
 	HUD.color = [UIColor colorWithRed:0.23 green:0.50 blue:0.82 alpha:0.90];
 	
 	HUD.delegate = self;
+	HUD.position = [self getPosition];
 	[HUD showWhileExecuting:@selector(myTask) onTarget:self withObject:nil animated:YES];	
 }
 

--- a/Demo/en.lproj/HudDemoViewController.xib
+++ b/Demo/en.lproj/HudDemoViewController.xib
@@ -7,6 +7,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HudDemoViewController">
             <connections>
+                <outlet property="horizontalSegmentedControl" destination="sIV-hA-RZI" id="cmL-lf-PfA"/>
+                <outlet property="verticalSegmentedControl" destination="7en-pe-W7s" id="Usf-cx-Ysh"/>
                 <outlet property="view" destination="52" id="70"/>
                 <outletCollection property="buttons" destination="8" id="1Qm-jt-yv2"/>
                 <outletCollection property="buttons" destination="9" id="EHW-ch-h6c"/>
@@ -26,17 +28,54 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="52">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="697"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="778"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="54">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="697"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="778"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <subviews>
-                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="9">
-                            <rect key="frame" x="20" y="68" width="280" height="40"/>
+                        <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" id="sIV-hA-RZI">
+                            <rect key="frame" x="20" y="20" width="280" height="29"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <segments>
+                                <segment title="Left"/>
+                                <segment title="Center"/>
+                                <segment title="Right"/>
+                            </segments>
+                        </segmentedControl>
+                        <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" id="7en-pe-W7s">
+                            <rect key="frame" x="20" y="57" width="280" height="29"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-15" maxX="0.0" maxY="15"/>
+                            <segments>
+                                <segment title="Top"/>
+                                <segment title="Center"/>
+                                <segment title="Bottom"/>
+                            </segments>
+                        </segmentedControl>
+                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8">
+                            <rect key="frame" x="20" y="94" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                            <state key="normal" title="Simple indeterminate progress">
+                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </state>
+                            <state key="highlighted">
+                                <color key="titleColor" red="0.0" green="0.23884613512332439" blue="0.49733664772727271" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </state>
+                            <connections>
+                                <action selector="showSimple:" destination="-1" eventType="touchUpInside" id="12"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="9">
+                            <rect key="frame" x="20" y="142" width="280" height="40"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="With label">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -50,9 +89,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="10">
-                            <rect key="frame" x="20" y="116" width="280" height="40"/>
+                            <rect key="frame" x="20" y="190" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="With details label">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -68,9 +108,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="16">
-                            <rect key="frame" x="20" y="164" width="280" height="40"/>
+                            <rect key="frame" x="20" y="238" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Determinate mode">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -84,9 +125,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="106">
-                            <rect key="frame" x="20" y="212" width="280" height="40"/>
+                            <rect key="frame" x="20" y="286" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Annular determinate mode">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -100,9 +142,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="117">
-                            <rect key="frame" x="20" y="257" width="280" height="44"/>
+                            <rect key="frame" x="20" y="334" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Bar determinate mode">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -115,10 +158,28 @@
                                 <action selector="showWithLabelDeterminateHorizontalBar:" destination="-1" eventType="touchUpInside" id="121"/>
                             </connections>
                         </button>
-                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="20">
-                            <rect key="frame" x="20" y="354" width="280" height="40"/>
+                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="43">
+                            <rect key="frame" x="20" y="382" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                            <state key="normal" title="Custom view">
+                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </state>
+                            <state key="highlighted">
+                                <color key="titleColor" red="0.0" green="0.23884613512332439" blue="0.49733664772727271" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </state>
+                            <connections>
+                                <action selector="showWithCustomView:" destination="-1" eventType="touchUpInside" id="47"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="20">
+                            <rect key="frame" x="20" y="430" width="280" height="40"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Mode switching">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -132,9 +193,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="49">
-                            <rect key="frame" x="20" y="400" width="280" height="44"/>
+                            <rect key="frame" x="20" y="478" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Using blocks">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -148,9 +210,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="71">
-                            <rect key="frame" x="20" y="450" width="280" height="40"/>
+                            <rect key="frame" x="20" y="526" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="On Window">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -164,9 +227,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="76">
-                            <rect key="frame" x="20" y="498" width="280" height="40"/>
+                            <rect key="frame" x="20" y="574" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="NSURLConnection">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -179,26 +243,11 @@
                                 <action selector="showURL:" destination="-1" eventType="touchUpInside" id="78"/>
                             </connections>
                         </button>
-                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="43">
-                            <rect key="frame" x="20" y="306" width="280" height="40"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <state key="normal" title="Custom view">
-                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" red="0.0" green="0.23884613512332439" blue="0.49733664772727271" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                            </state>
-                            <connections>
-                                <action selector="showWithCustomView:" destination="-1" eventType="touchUpInside" id="47"/>
-                            </connections>
-                        </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="79">
-                            <rect key="frame" x="20" y="545" width="280" height="40"/>
+                            <rect key="frame" x="20" y="622" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Dim background">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -212,9 +261,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="111">
-                            <rect key="frame" x="20" y="593" width="280" height="40"/>
+                            <rect key="frame" x="20" y="670" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Text only">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -228,9 +278,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="115">
-                            <rect key="frame" x="20" y="641" width="280" height="37"/>
+                            <rect key="frame" x="20" y="718" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                            <inset key="insetFor6xAndEarlier" minX="0.0" minY="-30" maxX="0.0" maxY="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <state key="normal" title="Colored">
                                 <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -243,27 +294,13 @@
                                 <action selector="showWithColor:" destination="-1" eventType="touchUpInside" id="116"/>
                             </connections>
                         </button>
-                        <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8">
-                            <rect key="frame" x="20" y="20" width="280" height="40"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" red="0.94901960784313721" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <state key="normal" title="Simple indeterminate progress">
-                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" red="0.0" green="0.23884613512332439" blue="0.49733664772727271" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                            </state>
-                            <connections>
-                                <action selector="showSimple:" destination="-1" eventType="touchUpInside" id="12"/>
-                            </connections>
-                        </button>
                     </subviews>
                     <color key="backgroundColor" red="0.8862745098" green="0.90588235289999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
+                    <inset key="insetFor6xAndEarlier" minX="0.0" minY="0.0" maxX="0.0" maxY="30"/>
                 </view>
             </subviews>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <inset key="insetFor6xAndEarlier" minX="0.0" minY="0.0" maxX="0.0" maxY="30"/>
         </scrollView>
     </objects>
 </document>

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -57,6 +57,16 @@ typedef enum {
 	MBProgressHUDAnimationZoomIn
 } MBProgressHUDAnimation;
 
+typedef enum {
+    MBProgressHUDPositionTop                = (1 << 0),
+	MBProgressHUDPositionCenterVertical     = (1 << 1),
+    MBProgressHUDPositionBottom             = (1 << 2),
+    MBProgressHUDPositionLeft               = (1 << 3),
+    MBProgressHUDPositionCenterHorizontal   = (1 << 4),
+    MBProgressHUDPositionRight              = (1 << 5),
+    MBProgressHUDPositionCenter = MBProgressHUDPositionCenterHorizontal | MBProgressHUDPositionCenterVertical,
+} MBProgressHUDPosition;
+
 
 #ifndef MB_INSTANCETYPE
 #if __has_feature(objc_instancetype)
@@ -291,6 +301,16 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) MBProgressHUDAnimation animationType;
 
 /**
+ * Where on the screen the HUD should be positioned.  The default is MBProgressHUDPositionCenter.
+ * xOffset and yOffset are applied relative to this position.
+ *
+ * @see MBProgressHUDPosition
+ * @see xOffset
+ * @see yOffset
+ */
+@property (assign) MBProgressHUDPosition position;
+
+/**
  * The UIView (e.g., a UIImageView) to be shown when the HUD is in MBProgressHUDModeCustomView.
  * For best results use a 37 by 37 pixel view (so the bounds match the built in indicator bounds). 
  */
@@ -329,12 +349,16 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (MB_STRONG) UIColor *color;
 
 /** 
- * The x-axis offset of the HUD relative to the centre of the superview. 
+ * The x-axis offset of the HUD relative to its position in the superview.
+ *
+ * @see position
  */
 @property (assign) float xOffset;
 
 /** 
- * The y-axis offset of the HUD relative to the centre of the superview. 
+ * The y-axis offset of the HUD relative to its position in the superview. 
+ *
+ * @see position
  */
 @property (assign) float yOffset;
 


### PR DESCRIPTION
The HUD can now be positioned relative not only to the center of the superview, but also relative to its top/bottom and left/right edges.  xOffset and yOffset apply as expected.  Default behavior is unaffected.

This is useful when you want to position the HUD near an edge of the screen and need to support multiple screen sizes and/or orientations.