### PR TITLE
Use the proper notification for status bar orientation change

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -716,7 +716,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 - (void)registerForNotifications {
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 	[nc addObserver:self selector:@selector(deviceOrientationDidChange:) 
-			   name:UIDeviceOrientationDidChangeNotification object:nil];
+			   name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
 }
 
 - (void)unregisterFromNotifications {


### PR DESCRIPTION
Currently you are using the UIDeviceOrientationDidChangeNotification which isn't quite right. Under certain conditions if you flip the device really fast you can end up with the top view upside down and the others right side up. The proper notification is UIApplicationDidChangeStatusBarOrientationNotification (which is what you're interested in after all since orientation is determined by status bar orientation, not device orientation).
