### PR TITLE
Set removeFromSuperViewOnHide to YES for convenience methods

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -115,6 +115,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 + (MB_INSTANCETYPE)showHUDAddedTo:(UIView *)view animated:(BOOL)animated {
 	MBProgressHUD *hud = [[self alloc] initWithView:view];
+	hud.removeFromSuperViewOnHide = YES;
 	[view addSubview:hud];
 	[hud show:animated];
 	return MB_AUTORELEASE(hud);


### PR DESCRIPTION
By setting `removeFromSuperViewOnHide` to `YES` for this convenience method we reduce the chance of memory leaks. People use `[MBProgressHUD showHUDAddedTo:animated:]` together with `hide:` and simply forget to remove the HUD view.

If people want the old behavior, they can simply set `removeFromSuperViewOnHide` to `NO` after calling `[MBProgressHUD showHUDAddedTo:animated:]`.
