### PR TITLE
Fixed race condition when you hide with delay and in the meantime you show the HUD again

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -313,7 +313,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 - (void)showUsingSavedAnimation {
 	// cancel delayed hide calls
-	[NSRunLoop cancelPreviousPerformRequestsWithTarget:self];
+	[NSObject cancelPreviousPerformRequestsWithTarget:self];
 	[self setNeedsDisplay];
 	[self showUsingAnimation:useAnimation];
 }

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -254,8 +254,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	} 
 	// ... otherwise show the HUD imediately 
 	else {
-		[self setNeedsDisplay];
-		[self showUsingAnimation:useAnimation];
+		[self showUsingSavedAnimation];
 	}
 }
 
@@ -288,8 +287,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 - (void)handleGraceTimer:(NSTimer *)theTimer {
 	// Show the HUD only if the task is still running
 	if (taskInProgress) {
-		[self setNeedsDisplay];
-		[self showUsingAnimation:useAnimation];
+		[self showUsingSavedAnimation];
 	}
 }
 
@@ -312,6 +310,13 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 }
 
 #pragma mark - Internal show & hide operations
+
+- (void)showUsingSavedAnimation {
+	// cancel delayed hide calls
+	[NSRunLoop cancelPreviousPerformRequestsWithTarget:self];
+	[self setNeedsDisplay];
+	[self showUsingAnimation:useAnimation];
+}
 
 - (void)showUsingAnimation:(BOOL)animated {
 	if (animated && animationType == MBProgressHUDAnimationZoomIn) {


### PR DESCRIPTION
Hey!

A simple fix in order to solve this problem I'm having in my projects.

The use of [NSObject cancelPreviousPerformRequestsWithTarget:self] is convenient since there's only one call to [self performSelector:...] but when more performSelector calls appear, it has to be changed to the other version of the method (passing both target, selector and argument)

Let me know if you have any question

Thanks!