### PR TITLE
Added Deployment Target

### DIFF
--- a/MBProgressHUD.podspec
+++ b/MBProgressHUD.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = '*.{h,m}'
   s.framework    = "CoreGraphics"
   s.requires_arc = true
+  s.ios.deployment_target = "6.0"
 end


### PR DESCRIPTION
If deployment target is not added, the podspec doesnt work with Copper (CocoaPod Manager)