### PR TITLE
- [BUG][iOS8] Incorrect HUD orientation

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -304,7 +304,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
     BOOL __block isPreiOS8;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        isPreiOS8 = ![UITraitCollection class];
+        isPreiOS8 = ![[UIScreen mainScreen] respondsToSelector:@selector(nativeBounds)];
     });
     
 	// prior to iOS8 code needs to take care of rotation if it is being added to the window


### PR DESCRIPTION
Incorrect HUD orientation when it's shown on windows, i.e. it has the main window as superview.
- Fixes the incorrect HUD orientation on applications linked against an SDK < 8.0 running on iOS 8.x
