### PR TITLE
Resolution optimisation of demo application for iPhone 6 / 6+

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -58,6 +58,8 @@
 			<string>{320, 480}</string>
 		</dict>
 	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>MainWindow</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
The demo application now runs in native resolution on iPhone 6 / 6+.

The layout looks to be adaptive, so no fixes were needed for this.