### PR TITLE
Implementing visibility state tracking.

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -57,6 +57,14 @@ typedef NS_ENUM(NSInteger, MBProgressHUDAnimation) {
 	MBProgressHUDAnimationZoomIn
 };
 
+typedef NS_ENUM(NSInteger, MBProgressHUDVisibilityState)
+{
+    MBProgressHUDVisibilityState_UNINITIALIZED=0,
+    MBProgressHUDVisibilityState_SHOWING,
+    MBProgressHUDVisibilityState_VISIBLE,
+    MBProgressHUDVisibilityState_HIDING,
+    MBProgressHUDVisibilityState_HIDDEN,
+};
 
 #ifndef MB_INSTANCETYPE
 #if __has_feature(objc_instancetype)
@@ -444,6 +452,12 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * Force the HUD dimensions to be equal if possible. 
  */
 @property (assign, getter = isSquare) BOOL square;
+
+
+/**
+ * Visibility state tracking.
+ */
+@property (atomic, assign) MBProgressHUDVisibilityState visibilityState;
 
 @end
 

--- a/MBProgressHUD.podspec
+++ b/MBProgressHUD.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MBProgressHUD"
-  s.version      = "0.9.1"
+  s.version      = "0.9.1.1"
   s.summary      = "An iOS activity indicator view."
   s.description  = <<-DESC
                     MBProgressHUD is an iOS drop-in class that displays a translucent HUD 

--- a/MBProgressHUD.podspec
+++ b/MBProgressHUD.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage     = "http://www.bukovinski.com"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { 'Matej Bukovinski' => 'matej@bukovinski.com' }
-  s.source       = { :git => "https://github.com/matej/MBProgressHUD.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/uShip/MBProgressHUD.git", :tag => s.version.to_s }
   s.platform     = :ios
   s.source_files = '*.{h,m}'
   s.framework    = "CoreGraphics"


### PR DESCRIPTION
This pull request implements an enum to track whether a HUD is visible, showing, hidden, or hiding.

Additionally, the "done" animation callback (renamed to "doneHiding") is made conditional such that it only executes if the existing visibility stated was "hiding".  This fixes issue 292. 

https://github.com/jdg/MBProgressHUD/issues/292
