### PR TITLE
Made label into a property (to enable subclassing from Swift)

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -69,6 +69,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @property (atomic, MB_STRONG) NSTimer *graceTimer;
 @property (atomic, MB_STRONG) NSTimer *minShowTimer;
 @property (atomic, MB_STRONG) NSDate *showStarted;
+@property (atomic, MB_STRONG) UIView *label;
 
 @end
 
@@ -77,6 +78,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 #pragma mark - Properties
 
+@synthesize label = label;
 @synthesize animationType;
 @synthesize delegate;
 @synthesize opacity;


### PR DESCRIPTION
With label as a private ivar, I couldn’t find a way to extend the class and add functionality (in my case, I needed to make the label three lines long for a certain message). If we make it into a property, I can at least declare label as @NSManaged and refer to it in my subclass. (Without violating encapsulation and keeping it private.)

Use case:

    class ABProgressHUD:MBProgressHUD
    {
        // The label property is in a private Objective-C category.
        // I’m using (abusing?) @NSManaged as I would dynamic in Objective-C.
        @NSManaged var label:UILabel
        
        func setNumberOfLinesInLabel(numberOfLines:Int)
        {
            label.numberOfLines = numberOfLines
        }
    }
