### PR TITLE
add completion block for hide:afterDelay

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -223,7 +223,20 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * @see animationType
  */
 - (void)hide:(BOOL)animated afterDelay:(NSTimeInterval)delay;
-
+/**
+ * Hide the method local hud variable after a delay. This will not calls the hudWasHidden:delegate as you can not contain a valid delete for a method local variable.
+ * This is still the counterpart of the show: method. Use it to
+ * hide the hud at the end of your method and it provide you the chance to remove you super window/view if needed.
+ *
+ * @param animated If set to YES the HUD will disappear using the current animationType. If set to NO the HUD will not use
+ * animations while disappearing.
+ * @param delay Delay in seconds until the HUD is hidden.
+ * @see animationType
+ *
+ * @param completion will be called when the hud was hidden.
+ *
+ */
+- (void)hide:(BOOL)animated afterDelay:(NSTimeInterval)delay completion:(MBProgressHUDCompletionBlock)completion;
 /** 
  * Shows the HUD while a background task is executing in a new thread, then hides the HUD.
  *

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -280,6 +280,12 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	[self performSelector:@selector(hideDelayed:) withObject:[NSNumber numberWithBool:animated] afterDelay:delay];
 }
 
+- (void)hide:(BOOL)animated afterDelay:(NSTimeInterval)delay completion:(MBProgressHUDCompletionBlock)completion
+{
+    self.completionBlock = completion;
+    [self performSelector:@selector(hideDelayed:) withObject:[NSNumber numberWithBool:animated] afterDelay:delay];
+}
+
 - (void)hideDelayed:(NSNumber *)animated {
 	[self hide:[animated boolValue]];
 }


### PR DESCRIPTION
#use example:

-(void)showIcon:(NSString*)imageName withTitle:(NSString*)title description:(NSString*)description
{
    MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:[self window] animated:YES];
    hud.mode = MBProgressHUDModeCustomView;
    hud.customView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:imageName]] autorelease];
    hud.labelText = title;
    hud.detailsLabelText = description;
    hud.margin = 20.f;
    hud.removeFromSuperViewOnHide = YES;
    [hud hide:YES afterDelay:3 completion:^{
        [self releaseWindow];
    }];
}