### PR TITLE
changed completionBlock handling

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -220,15 +220,16 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 
 - (void)hideUsingAnimation:(BOOL)animated {
     if (animated && self.showStarted) {
+        self.showStarted = nil;
         [self animateIn:NO withType:self.animationType completion:^(BOOL finished) {
             [self done];
         }];
     } else {
+        self.showStarted = nil;
         self.bezelView.alpha = 0.f;
         self.backgroundView.alpha = 1.f;
         [self done];
     }
-    self.showStarted = nil;
 }
 
 - (void)animateIn:(BOOL)animatingIn withType:(MBProgressHUDAnimation)type completion:(void(^)(BOOL finished))completion {
@@ -281,10 +282,10 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
         [self removeFromSuperview];
     }
     if (self.completionBlock) {
-        self.completionBlock();
+        MBProgressHUDCompletionBlock block = self.completionBlock;
         self.completionBlock = NULL;
+        block();
     }
-
     id<MBProgressHUDDelegate> delegate = self.delegate;
     if ([delegate respondsToSelector:@selector(hudWasHidden:)]) {
         [delegate performSelector:@selector(hudWasHidden:) withObject:self];


### PR DESCRIPTION
Very little changes to the handling of the completionBlock. This changes do not change the behavior of the class, but they make the HUD reentrant for code inside of the completionBlock.

Before the changes i had some problems setting up a new HUD from inside the completionBlock.
With this changes you can use the "showStarted" property inside the completionBlock, because it is set before the "done" method is called.

There should be no side effects by these changes.