### PR TITLE
Don't depend on `finished` from animation completion block

### DIFF
--- a/Demo/HudTests/HudTests.m
+++ b/Demo/HudTests/HudTests.m
@@ -156,6 +156,31 @@ XCTAssertNil(hud.superview, @"The HUD should not have a superview."); \
     [hud removeFromSuperview];
 }
 
+- (void)testUnfinishedHidingAnimation {
+  UIViewController *rootViewController = UIApplication.sharedApplication.keyWindow.rootViewController;
+  UIView *rootView = rootViewController.view;
+
+  MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:rootView animated:NO];
+
+  [hud hideAnimated:YES];
+
+  // Cancel all animations. It will cause `UIView+animate...` to call completionBlock with `finished = NO`.
+  // It's same as if you call `[hud hideAnimated:YES]` while the app is in background.
+  [hud.bezelView.layer removeAllAnimations];
+  [hud.backgroundView.layer removeAllAnimations];
+
+  XCTestExpectation *hideCheckExpectation = [self expectationWithDescription:@"Hide check"];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    // After the grace time passes, the HUD should still not be shown.
+    MBTestHUDIsHidenAndRemoved(hud, rootView);
+    [hideCheckExpectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:5. handler:nil];
+
+  MBTestHUDIsHidenAndRemoved(hud, rootView);
+}
+
 - (void)testAnimatedImmediateHudReuse {
     UIViewController *rootViewController = UIApplication.sharedApplication.keyWindow.rootViewController;
     UIView *rootView = rootViewController.view;

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -231,13 +231,13 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     if (animated && self.showStarted) {
         self.showStarted = nil;
         [self animateIn:NO withType:self.animationType completion:^(BOOL finished) {
-            [self doneFinished:finished];
+            [self done];
         }];
     } else {
         self.showStarted = nil;
         self.bezelView.alpha = 0.f;
         self.backgroundView.alpha = 1.f;
-        [self doneFinished:YES];
+        [self done];
     }
 }
 
@@ -284,11 +284,11 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     [UIView animateWithDuration:0.3 delay:0. options:UIViewAnimationOptionBeginFromCurrentState animations:animations completion:completion];
 }
 
-- (void)doneFinished:(BOOL)finished {
+- (void)done {
     // Cancel any scheduled hideDelayed: calls
     [self.hideDelayTimer invalidate];
 
-    if (finished) {
+    if (self.hasFinished) {
         self.alpha = 0.0f;
         if (self.removeFromSuperViewOnHide) {
             [self removeFromSuperview];


### PR DESCRIPTION
Steps to reproduce in the sample app

1. Tap on a "Determinate mode" to bring the HUD
2. While the HUS is still presented background the app
3. Wait for 5 seconds until the HUD should have disappered
4. Foreground the app

Expected: no HUD, you can interact with the app.
Result without this: you can't interact with the app.

You could probably reproduce it in other apps using this library by backgrounding the app while the HUD is presented and then foregrounding it after `MBProgressHUD#hideAnimated:` is called. Unless you specify 

It happens because HUD wasn't removed from its superview. And it wasn't removed because the app was in background when `hideAnimated:` was called and animation wasn't finished.

---

From what I [found](https://github.com/jdg/MBProgressHUD/commit/f39a83aef637b3c6fb0c1adc160b8cbb894a7b9a) the `finished` parameter was used to avoid removing the HUD from view hierarchy if it gets `showAnimated:` shortly after `hideAnimated`. BTW, unit tests are really helpful for understanding reasoning behind some changes 👍 

I think this shouldn't depend on `finished` passed into completionBlock by `UIView+animateWithDuration:...`. As we've explored `finished` will be false when `hideAnimated:` was called when the app was in background.

Instead, we can use property the library already has:

```objective-c
- (void)showAnimated:(BOOL)animated {
    // ...
    self.finished = NO;
    // ...
}

- (void)hideAnimated:(BOOL)animated {
    // ...
    self.finished = YES;
    // ...
}
```

Passing unit tests prove that we are still getting the behavior we need when we reuse the HUD shortly after calling `hideAnimated` (`testAnimatedImmediateHudReuse` test).

<s>I've also tried to right a unit test for the error case I've described above, but didn't figure out how to make `UIView+animateWithDuration:...` call completion block with `finished` equal false. </s>