### PR TITLE
Keep bounds.origin is always CGPointZero

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -784,7 +784,7 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 - (void)updateForCurrentOrientationAnimated:(BOOL)animated {
     // Stay in sync with the superview in any case
     if (self.superview) {
-        self.bounds = self.superview.bounds;
+        self.frame = self.superview.bounds;
     }
 
     // Not needed on iOS 8+, compile out when the deployment target allows,


### PR DESCRIPTION
I wrote a subclass for displaying hud on scrollView.
Then I found a bug of `MBProgressHUD`, Please see `setBounds:` below.
I think `self.bounds = self.superview.bounds;` in `updateForCurrentOrientationAnimated:` is wrong.

```
@interface MLProgressHUD()

@end

@implementation MLProgressHUD

#pragma mark - for scrollView
- (void)willMoveToSuperview:(UIView *)newSuperview {
    [super willMoveToSuperview:newSuperview];

    if ([self.superview isKindOfClass:[UIScrollView class]]) {
        //remove kvo
        [self.superview removeObserver:self forKeyPath:@"contentOffset" context:nil];

        if ([self.superview isKindOfClass:[UIScrollView class]]) {
            ((UIScrollView*)self.superview).userInteractionEnabled = YES;
        }
    }
}

- (void)didMoveToSuperview {
    [super didMoveToSuperview];

    if ([self.superview isKindOfClass:[UIScrollView class]]) {
        //add kvo
        [self.superview addObserver:self forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionInitial context:nil];

        if ([self.superview isKindOfClass:[UIScrollView class]]) {
            self.superview.userInteractionEnabled = !self.userInteractionEnabled;
        }
    }
}

#pragma mark - kvo
- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
    if ([@"contentOffset" isEqualToString:keyPath]) {
        UIScrollView *scrollView = (UIScrollView*)self.superview;
        self.frame = scrollView.bounds;
    }else{
        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
    }

}

#pragma mark - fix bug of MBProgressHUD `updateForCurrentOrientationAnimated:`
- (void)setBounds:(CGRect)bounds {
    bounds.origin = CGPointZero;
    [super setBounds:bounds];
}

#pragma mark - set
- (void)setUserInteractionEnabled:(BOOL)userInteractionEnabled {
    [super setUserInteractionEnabled:userInteractionEnabled];

    if ([self.superview isKindOfClass:[UIScrollView class]]) {
        ((UIScrollView*)self.superview).userInteractionEnabled = !userInteractionEnabled;
    }
}
@end
```
