### PR TITLE
Check animation is finished on hide

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -234,7 +234,9 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     if (animated && self.showStarted) {
         self.showStarted = nil;
         [self animateIn:NO withType:self.animationType completion:^(BOOL finished) {
-            [self done];
+	    if (finished) {
+	      [self done];
+	    }
         }];
     } else {
         self.showStarted = nil;


### PR DESCRIPTION
Fixes hide - show - hide race condition, holding the HUD on screen. Call
"done" only when the animation has finished as the show cycle could have
been restarted.

Steps to reproduce:
- Create a single instance of the HUD for your notifications.
- Show and hide animated with a timer.
- Call another show/hide cycle again right when the hide animation is taking place.
- The HUD will hold on screen and never disappear.

This is an easy fix although it was difficult to pinpoint. On [Blink Shell](http://github.com/blinksh/blink) we use MBProgressHUD as a way to show changes between terminals. We change the content of the HUD instead of creating a new instance, and a new show-hide cycle must start.

Thanks!
