### PR TITLE
Restrict framework to extension-safe API

### DIFF
--- a/MBProgressHUD.xcodeproj/project.pbxproj
+++ b/MBProgressHUD.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		1D104D8E1ACA36CC00973364 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -258,6 +259,7 @@
 		1D104D8F1ACA36CC00973364 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;


### PR DESCRIPTION
This allows the HUD to be used e.g. in iMessage app extension