### PR TITLE
Fix show multiple Hud’s and them to hide them

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Showing and hiding
 
 /**
- * Finds the top-most HUD subview and hides it. The counterpart to this method is showHUDAddedTo:animated:.
+ * Finds the top-most HUD subview that hasn't finished and hides it. The counterpart to this method is showHUDAddedTo:animated:.
  *
  * @note This method sets removeFromSuperViewOnHide. The HUD will automatically be removed from the view hierarchy when hidden.
  *
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated;
 
 /**
- * Finds the top-most HUD subview and returns it. 
+ * Finds the top-most HUD subview that hasn't finished and returns it.
  *
  * @param view The view that is going to be searched.
  * @return A reference to the last HUD subview discovered.

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -80,7 +80,10 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     NSEnumerator *subviewsEnum = [view.subviews reverseObjectEnumerator];
     for (UIView *subview in subviewsEnum) {
         if ([subview isKindOfClass:self]) {
-            return (MBProgressHUD *)subview;
+            MBProgressHUD *hud = (MBProgressHUD *)subview;
+            if (hud.hasFinished == NO) {
+                return hud;
+            }
         }
     }
     return nil;


### PR DESCRIPTION
I found a problem.

If I call `+ (instancetype)showHUDAddedTo:(UIView *)view animated:(BOOL)animated;` twice and then `+ (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated;` twice, it doesn't hide the `MBProgressHUD`.

The problem is in the method `+ (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated;` that return's the same view in booth method calls.
So I modify it to look for  that hasn't finished yet.