### PR TITLE
Fix broken image link in README.md

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -8,7 +8,7 @@
 [![](https://cloud.githubusercontent.com/assets/91322/26737574/95128ef6-477f-11e7-8b3a-456b2b585e75.png)](https://cloud.githubusercontent.com/assets/91322/26737572/94a137a6-477f-11e7-9778-6266006f2dba.png)
 [![](https://cloud.githubusercontent.com/assets/91322/26737576/951cc0c4-477f-11e7-9bc4-891cbbe70f80.png)](https://cloud.githubusercontent.com/assets/91322/26737575/95178c6c-477f-11e7-8df9-03aeeca5d39d.png)
 [![](https://cloud.githubusercontent.com/assets/91322/26737577/9523169a-477f-11e7-83d9-c1a55b724c0a.png)](https://cloud.githubusercontent.com/assets/91322/26737578/95235920-477f-11e7-9968-9ecf506aba06.png)
-[![](https://cloud.githubusercontent.com/assets/91322/26737579/954371ce-477f-11e7-85f8-660807a7f35e.png)](https://cloud.githubusercontent.com/assets/91322/26737573/95048432-477f-11e7-8f1d-4d5736b10488.)
+[![](https://cloud.githubusercontent.com/assets/91322/26737579/954371ce-477f-11e7-85f8-660807a7f35e.png)](https://cloud.githubusercontent.com/assets/91322/26737573/95048432-477f-11e7-8f1d-4d5736b10488.png)
 [![](https://cloud.githubusercontent.com/assets/91322/26737581/954e3c9e-477f-11e7-93d9-2a8e2e0e7dd0.png)](https://cloud.githubusercontent.com/assets/91322/26737580/954aff70-477f-11e7-9634-5802daea2dee.png)
 [![](https://cloud.githubusercontent.com/assets/91322/26737583/955ba17c-477f-11e7-93aa-d952fb0bbce3.png)](https://cloud.githubusercontent.com/assets/91322/26737582/9552886c-477f-11e7-8e90-46acd9a8527c.png)
 [![](https://cloud.githubusercontent.com/assets/91322/26737585/95a31822-477f-11e7-9ca6-b33ceb3a3f49.png)](https://cloud.githubusercontent.com/assets/91322/26737584/956392f6-477f-11e7-918f-717a42758156.png)


### PR DESCRIPTION
### Abstract
Fix broken image link in README.md

------

###  Cause Commit
https://github.com/jdg/MBProgressHUD/commit/a7c3601fbd58946c9dc0892ab9394f2e1f3c4d89
<img width="1355" alt="problem commit" src="https://user-images.githubusercontent.com/4126751/29558668-1e013e1e-872d-11e7-8c67-c753ec466c4e.png">



### Before fix

<img width="930" alt="broken" src="https://user-images.githubusercontent.com/4126751/29558325-07d567a6-872c-11e7-8900-9f23648861ee.png">
 ↓↓↓↓
<img width="859" alt="link error" src="https://user-images.githubusercontent.com/4126751/29558320-0594b500-872c-11e7-9d25-0ad413e3b646.png">

----

### After fix

<img width="930" alt="broken" src="https://user-images.githubusercontent.com/4126751/29558325-07d567a6-872c-11e7-8900-9f23648861ee.png">
 ↓↓↓↓
<img width="423" alt="fix" src="https://user-images.githubusercontent.com/4126751/29558499-8b214184-872c-11e7-8aaa-29e4d23414bd.png">\

