### PR TITLE
 Add interaction mode of the HUD

### DIFF
--- a/Demo/HudDemo/MBHudDemoViewController.m
+++ b/Demo/HudDemo/MBHudDemoViewController.m
@@ -49,6 +49,9 @@
     @[@[[MBExample exampleWithTitle:@"Indeterminate mode" selector:@selector(indeterminateExample)],
         [MBExample exampleWithTitle:@"With label" selector:@selector(labelExample)],
         [MBExample exampleWithTitle:@"With details label" selector:@selector(detailsLabelExample)]],
+      @[[MBExample exampleWithTitle:@"Block all touches mode" selector:@selector(blockAllTouchesExample)],
+        [MBExample exampleWithTitle:@"Block touches on hud mode" selector:@selector(blockTouchesOnHudExample)],
+        [MBExample exampleWithTitle:@"Block no touches mode" selector:@selector(blockNoTouchesExample)]],
       @[[MBExample exampleWithTitle:@"Determinate mode" selector:@selector(determinateExample)],
         [MBExample exampleWithTitle:@"Annular determinate mode" selector:@selector(annularDeterminateExample)],
         [MBExample exampleWithTitle:@"Bar determinate mode" selector:@selector(barDeterminateExample)]],
@@ -110,6 +113,54 @@
     // Set the details label text. Let's make it multiline this time.
     hud.detailsLabel.text = NSLocalizedString(@"Parsing data\n(1/1)", @"HUD title");
 
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [self doSomeWork];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [hud hideAnimated:YES];
+        });
+    });
+}
+
+- (void)blockAllTouchesExample {
+    MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:self.navigationController.view animated:YES];
+    hud.interactionMode = MBProgressHUDInteractionModeBlockAllTouches;
+    // Set the label text.
+    hud.label.text = NSLocalizedString(@"Loading...", @"HUD loading title");
+    // You can also adjust other label properties if needed.
+    // hud.label.font = [UIFont italicSystemFontOfSize:16.f];
+    
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [self doSomeWork];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [hud hideAnimated:YES];
+        });
+    });
+}
+
+- (void)blockTouchesOnHudExample {
+    MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:self.navigationController.view animated:YES];
+    hud.interactionMode = MBProgressHUDInteractionModeBlockTouchesOnHUDView;
+    // Set the label text.
+    hud.label.text = NSLocalizedString(@"Loading...", @"HUD loading title");
+    // You can also adjust other label properties if needed.
+    // hud.label.font = [UIFont italicSystemFontOfSize:16.f];
+    
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [self doSomeWork];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [hud hideAnimated:YES];
+        });
+    });
+}
+
+- (void)blockNoTouchesExample {
+    MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:self.navigationController.view animated:YES];
+    hud.interactionMode = MBProgressHUDInteractionModeBlockNoTouches;
+    // Set the label text.
+    hud.label.text = NSLocalizedString(@"Loading...", @"HUD loading title");
+    // You can also adjust other label properties if needed.
+    // hud.label.font = [UIFont italicSystemFontOfSize:16.f];
+    
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
         [self doSomeWork];
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -69,6 +69,15 @@ typedef NS_ENUM(NSInteger, MBProgressHUDBackgroundStyle) {
     MBProgressHUDBackgroundStyleBlur
 };
 
+typedef NS_ENUM(NSUInteger, MBProgressHUDInteractionMode) {
+    /// Block all touches. No interaction behin the HUD is possible
+    MBProgressHUDInteractionModeBlockAllTouches = 0,
+    /// Block touches on the HUD view
+    MBProgressHUDInteractionModeBlockTouchesOnHUDView,
+    /// Block no touches
+    MBProgressHUDInteractionModeBlockNoTouches
+};
+
 typedef void (^MBProgressHUDCompletionBlock)(void);
 
 
@@ -213,6 +222,12 @@ NS_ASSUME_NONNULL_BEGIN
  * MBProgressHUD operation mode. The default is MBProgressHUDModeIndeterminate.
  */
 @property (assign, nonatomic) MBProgressHUDMode mode;
+
+/**
+ * Interaction mode of the HUD. Determines whether touches should be let through to the views
+ behind the HUD. The default is MBProgressHUDInteractionModeBlockAllTouches.
+ */
+@property (assign, nonatomic) MBProgressHUDInteractionMode interactionMode;
 
 /**
  * A color that gets forwarded to all labels and supported indicators. Also sets the tintColor

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -119,6 +119,22 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     [self unregisterFromNotifications];
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    if (self.interactionMode == MBProgressHUDInteractionModeBlockNoTouches) {
+        return nil;
+    } else {
+        UIView *view = [super hitTest:point withEvent:event];
+        
+        if (self.interactionMode == MBProgressHUDInteractionModeBlockAllTouches) {
+            return view;
+        }
+        else if (self.interactionMode == MBProgressHUDInteractionModeBlockTouchesOnHUDView && view != self.backgroundView) {
+            return view;
+        }
+        return nil;
+    }
+}
+
 #pragma mark - Show & hide
 
 - (void)showAnimated:(BOOL)animated {


### PR DESCRIPTION
Determines whether touches should be let through to the views
 behind the HUD.
The simulator is not smooth.
![interaction_demo](https://user-images.githubusercontent.com/13459701/50511089-29f1e880-0ac7-11e9-866b-a2b5d430c8ec.gif)

