### PR TITLE
Add support for SwiftPM & Accio

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,11 @@ let package = Package(
     targets: [
         .target(
             name: "MBProgressHUD",
+            dependencies: [],
             path: ".",
             exclude: ["Demo"],
-            sources: ["MBProgressHUD.h", "MBProgressHUD.m"]
+            sources: ["MBProgressHUD.h", "MBProgressHUD.m"],
+            publicHeadersPath: "include"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "MBProgressHUD",
+    products: [
+        .library(name: "MBProgressHUD", targets: ["MBProgressHUD"])
+    ],
+    targets: [
+        .target(
+            name: "MBProgressHUD",
+            path: ".",
+            exclude: ["Demo"],
+            sources: ["MBProgressHUD.h", "MBProgressHUD.m"]
+        )
+    ]
+)

--- a/README.mdown
+++ b/README.mdown
@@ -41,7 +41,7 @@ You will need the latest developer tools in order to build `MBProgressHUD`. Old 
 2. Run `carthage update`
 3. Follow the rest of the [standard Carthage installation instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) to add MBProgressHUD to your project.
 
-### Accio
+### SwiftPM / Accio
 
 1. Add the following to your `Package.swift`:
 	```swift
@@ -51,7 +51,7 @@ You will need the latest developer tools in order to build `MBProgressHUD`. Old 
 	```swift
 	.target(name: "App", dependencies: ["MBProgressHUD"]),
 	```
-3. Then run `accio update`.
+3. Then open your project in Xcode 11+ (SwiftPM) or run `accio update` (Accio).
 
 ### Source files
 

--- a/README.mdown
+++ b/README.mdown
@@ -1,7 +1,7 @@
 # MBProgressHUD
 
 [![Build Status](https://travis-ci.org/matej/MBProgressHUD.svg?branch=master)](https://travis-ci.org/matej/MBProgressHUD) [![codecov.io](https://codecov.io/github/matej/MBProgressHUD/coverage.svg?branch=master)](https://codecov.io/github/matej/MBProgressHUD?branch=master)
- [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) [![CocoaPods compatible](https://img.shields.io/cocoapods/v/MBProgressHUD.svg?style=flat)](https://cocoapods.org/pods/MBProgressHUD) [![License: MIT](https://img.shields.io/cocoapods/l/MBProgressHUD.svg?style=flat)](http://opensource.org/licenses/MIT)
+ [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) [![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio) [![CocoaPods compatible](https://img.shields.io/cocoapods/v/MBProgressHUD.svg?style=flat)](https://cocoapods.org/pods/MBProgressHUD) [![License: MIT](https://img.shields.io/cocoapods/l/MBProgressHUD.svg?style=flat)](http://opensource.org/licenses/MIT)
 
 `MBProgressHUD` is an iOS drop-in class that displays a translucent HUD with an indicator and/or labels while work is being done in a background thread. The HUD is meant as a replacement for the undocumented, private `UIKit` `UIProgressHUD` with some additional features.
 
@@ -40,6 +40,18 @@ You will need the latest developer tools in order to build `MBProgressHUD`. Old 
 1. Add MBProgressHUD to your Cartfile. e.g., `github "jdg/MBProgressHUD" ~> 1.1.0`
 2. Run `carthage update`
 3. Follow the rest of the [standard Carthage installation instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) to add MBProgressHUD to your project.
+
+### Accio
+
+1. Add the following to your `Package.swift`:
+	```swift
+	.package(url: "https://github.com/jdg/MBProgressHUD.git", .upToNextMajor(from: "1.1.0")),
+	```
+2. Next, add `MBProgressHUD` to your App targets dependencies like so:
+	```swift
+	.target(name: "App", dependencies: ["MBProgressHUD"]),
+	```
+3. Then run `accio update`.
 
 ### Source files
 

--- a/README.mdown
+++ b/README.mdown
@@ -1,7 +1,7 @@
 # MBProgressHUD
 
 [![Build Status](https://travis-ci.org/matej/MBProgressHUD.svg?branch=master)](https://travis-ci.org/matej/MBProgressHUD) [![codecov.io](https://codecov.io/github/matej/MBProgressHUD/coverage.svg?branch=master)](https://codecov.io/github/matej/MBProgressHUD?branch=master)
- [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) [![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio) [![CocoaPods compatible](https://img.shields.io/cocoapods/v/MBProgressHUD.svg?style=flat)](https://cocoapods.org/pods/MBProgressHUD) [![License: MIT](https://img.shields.io/cocoapods/l/MBProgressHUD.svg?style=flat)](http://opensource.org/licenses/MIT)
+ [![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) [![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio) [![CocoaPods compatible](https://img.shields.io/cocoapods/v/MBProgressHUD.svg?style=flat)](https://cocoapods.org/pods/MBProgressHUD) [![License: MIT](https://img.shields.io/cocoapods/l/MBProgressHUD.svg?style=flat)](http://opensource.org/licenses/MIT)
 
 `MBProgressHUD` is an iOS drop-in class that displays a translucent HUD with an indicator and/or labels while work is being done in a background thread. The HUD is meant as a replacement for the undocumented, private `UIKit` `UIProgressHUD` with some additional features.
 
@@ -13,7 +13,7 @@
 [![](https://raw.githubusercontent.com/wiki/matej/MBProgressHUD/Screenshots/6-small.png)](https://raw.githubusercontent.com/wiki/matej/MBProgressHUD/Screenshots/6.png)
 [![](https://raw.githubusercontent.com/wiki/matej/MBProgressHUD/Screenshots/7-small.png)](https://raw.githubusercontent.com/wiki/matej/MBProgressHUD/Screenshots/7.png)
 
-**NOTE:** The class has recently undergone a major rewrite. The old version is available in the [legacy](https://github.com/jdg/MBProgressHUD/tree/legacy) branch, should you need it. 
+**NOTE:** The class has recently undergone a major rewrite. The old version is available in the [legacy](https://github.com/jdg/MBProgressHUD/tree/legacy) branch, should you need it.
 
 ## Requirements
 
@@ -84,7 +84,7 @@ dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
 });
 ```
 
-You can add the HUD on any view or window. It is however a good idea to avoid adding the HUD to certain `UIKit` views with complex view hierarchies - like `UITableView` or `UICollectionView`. Those can mutate their subviews in unexpected ways and thereby break HUD display. 
+You can add the HUD on any view or window. It is however a good idea to avoid adding the HUD to certain `UIKit` views with complex view hierarchies - like `UITableView` or `UICollectionView`. Those can mutate their subviews in unexpected ways and thereby break HUD display.
 
 If you need to configure the HUD you can do this by using the MBProgressHUD reference that showHUDAddedTo:animated: returns.
 
@@ -135,4 +135,4 @@ This code is distributed under the terms and conditions of the [MIT license](LIC
 
 ## Change-log
 
-A brief summary of each MBProgressHUD release can be found in the [CHANGELOG](CHANGELOG.mdown). 
+A brief summary of each MBProgressHUD release can be found in the [CHANGELOG](CHANGELOG.mdown).

--- a/include/MBProgressHUD/MBProgressHUD.h
+++ b/include/MBProgressHUD/MBProgressHUD.h
@@ -1,0 +1,1 @@
+../../MBProgressHUD.h

--- a/include/module.modulemap
+++ b/include/module.modulemap
@@ -1,0 +1,5 @@
+module MBProgressHUD {
+     umbrella header "MBProgressHUD/MBProgressHUD.h"
+     export *
+     module * { export * }
+ }


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but may also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).