### PR TITLE
Main thread checker

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -482,8 +482,9 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 
         UIMotionEffectGroup *group = [[UIMotionEffectGroup alloc] init];
         group.motionEffects = @[effectX, effectY];
-
-        [bezelView addMotionEffect:group];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [bezelView addMotionEffect:group];
+        });
     } else {
         NSArray *effects = [bezelView motionEffects];
         for (UIMotionEffect *effect in effects) {


### PR DESCRIPTION
**Fix for**: http://www.openradar.me/45003816 

Creating a new instance of CMMotionManager always results in a Thread Checker exception, on iPhone XR, XSMax 

**Log:** Main Thread Checker: UI API called on a background thread: -[UIApplication applicationState] 

**Solution:** force call of UIView _- (void)addMotionEffect:(UIMotionEffect *)effect_  method from main thread.