### PR TITLE
Fix swift compiler error

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param view The view that is going to be searched.
  * @return A reference to the last HUD subview discovered.
  */
-+ (nullable MBProgressHUD *)HUDForView:(UIView *)view;
++ (nullable MBProgressHUD *)HUDForView:(UIView *)view NS_SWIFT_NAME(forView(_:));
 
 /**
  * A convenience constructor that initializes the HUD with the view's bounds. Calls the designated constructor with


### PR DESCRIPTION
Swift compiler treats `MBProgressHUD.HUDForView(_ view:)` as erroneous method, suggesting a fix-it that replaces the call with `.init(with view:)`
Adding an `NS_SWIFT_NAME` macro with non-capitalized function name that is exported to swift solves the issue (and makes swift API more intuitive)