### PR TITLE
Fix behavior inconsistencies

### DIFF
--- a/Demo/HudTests/HudTests.m
+++ b/Demo/HudTests/HudTests.m
@@ -267,7 +267,7 @@ XCTAssertNil(hud.superview, @"The HUD should not have a superview."); \
     MBTestHUDIsHidenAndRemoved(hud, rootView);
 }
 
-#pragma mark - Ruse
+#pragma mark - Reuse
 
 - (void)testNonAnimatedHudReuse {
     UIViewController *rootViewController = UIApplication.sharedApplication.keyWindow.rootViewController;
@@ -285,6 +285,31 @@ XCTAssertNil(hud.superview, @"The HUD should not have a superview."); \
     MBTestHUDIsVisible(hud, rootView);
 
     [hud hideAnimated:NO];
+    [hud removeFromSuperview];
+}
+
+- (void)testMixAndMatchHudReuseWithZoomInAnimation {
+    UIViewController *rootViewController = UIApplication.sharedApplication.keyWindow.rootViewController;
+    UIView *rootView = rootViewController.view;
+    
+    MBProgressHUD *hud = [[MBProgressHUD alloc] initWithView:rootView];
+    hud.animationType = MBProgressHUDAnimationZoomIn;
+    [rootView addSubview:hud];
+    [hud showAnimated:NO];
+    
+    XCTAssertNotNil(hud, @"A HUD should be created.");
+    
+    [hud hideAnimated:YES];
+    [hud showAnimated:NO];
+    
+    XCTAssertTrue(CGAffineTransformEqualToTransform(hud.bezelView.transform, CGAffineTransformIdentity), @"The HUD should have no transformations.");
+    
+    MBTestHUDIsVisible(hud, rootView);
+    
+    [hud hideAnimated:NO];
+    
+    XCTAssertEqual(hud.backgroundView.alpha, 0.f, @"The background view should be hidden.");
+    
     [hud removeFromSuperview];
 }
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -229,7 +229,7 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     } else {
         self.showStarted = nil;
         self.bezelView.alpha = 0.f;
-        self.backgroundView.alpha = 1.f;
+        self.backgroundView.alpha = 0.f;
         [self done];
     }
 }

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -209,6 +209,7 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     if (animated) {
         [self animateIn:YES withType:self.animationType completion:NULL];
     } else {
+        self.bezelView.transform = CGAffineTransformIdentity;
         self.bezelView.alpha = 1.f;
         self.backgroundView.alpha = 1.f;
     }


### PR DESCRIPTION
Hi!

With this PR I fixed several behavior bugs and added a test for these cases.

They are:

1. If you try to hide a hud without animation, the `alpha` value for the `backgroundView` will be equal to `1.0` while it must be equal to `0.0`
2. If you have a hud with an animation type set to `MBProgressHUDAnimationZoomIn` and you hide this hud animatedly, trying to show it non-animated will end up in having a transform applied to the hub as a result of animated hide which is undesirable behavior.