### PR TITLE
Add iOS 13 Dark Mode support

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -82,7 +82,12 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     _mode = MBProgressHUDModeIndeterminate;
     _margin = 20.0f;
     _defaultMotionEffectsEnabled = NO;
-    _contentColor = [UIColor colorWithWhite:0.f alpha:0.7f];
+
+    if (@available(iOS 13.0, *)) {
+       _contentColor = [[UIColor labelColor] colorWithAlphaComponent:0.7f];
+    } else {
+        _contentColor = [UIColor colorWithWhite:0.f alpha:0.7f];
+    }
 
     // Transparent background
     self.opaque = NO;
@@ -1042,8 +1047,13 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 - (instancetype)initWithFrame:(CGRect)frame {
     if ((self = [super initWithFrame:frame])) {
         _style = MBProgressHUDBackgroundStyleBlur;
-        _blurEffectStyle = UIBlurEffectStyleLight;
-        _color = [UIColor colorWithWhite:0.8f alpha:0.6f];
+        if (@available(iOS 13.0, *)) {
+            _blurEffectStyle = UIBlurEffectStyleSystemMaterial;
+            _color = [[UIColor secondarySystemBackgroundColor] colorWithAlphaComponent:0.8f];
+        } else {
+            _blurEffectStyle = UIBlurEffectStyleLight;
+            _color = [UIColor colorWithWhite:0.8f alpha:0.6f];
+        }
 
         self.clipsToBounds = YES;
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -1048,7 +1048,7 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
     if ((self = [super initWithFrame:frame])) {
         _style = MBProgressHUDBackgroundStyleBlur;
         if (@available(iOS 13.0, *)) {
-            _blurEffectStyle = UIBlurEffectStyleSystemMaterial;
+            _blurEffectStyle = UIBlurEffectStyleRegular;
             _color = [[UIColor secondarySystemBackgroundColor] colorWithAlphaComponent:0.8f];
         } else {
             _blurEffectStyle = UIBlurEffectStyleLight;


### PR DESCRIPTION
This adds dark mode support for iOS 13. I adjusted the default colors so users of this library don't need to manually set the color using the new systemColors of UIColor.