### PR TITLE
Empty button shown beneath spinner when latest Facebook SDK is used.

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -302,7 +302,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) UILabel *detailsLabel;
 
 /**
- * A button that is placed below the labels. Visible only if a target / action is added. 
+ * A button that is placed below the labels. Visible only if a target / action is added and a title is assigned.. 
  */
 @property (strong, nonatomic, readonly) UIButton *button;
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -1143,7 +1143,7 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 
 - (CGSize)intrinsicContentSize {
     // Only show if we have associated control events and a title
-    if ((self.allControlEvents == 0) && ([self titleForState:UIControlStateNormal].length == 0))
+    if ((self.allControlEvents == 0) || ([self titleForState:UIControlStateNormal].length == 0))
 		return CGSizeZero;
     CGSize size = [super intrinsicContentSize];
     // Add some side padding

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -1142,8 +1142,9 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 }
 
 - (CGSize)intrinsicContentSize {
-    // Only show if we have associated control events
-    if (self.allControlEvents == 0) return CGSizeZero;
+    // Only show if we have associated control events and a title
+    if ((self.allControlEvents == 0) && ([self titleForState:UIControlStateNormal].length == 0))
+		return CGSizeZero;
     CGSize size = [super intrinsicContentSize];
     // Add some side padding
     size.width += 20.f;


### PR DESCRIPTION
Facebook swizzles a lot and adds targets to buttons in order to track conversions. The previous criteria to show the button was if it had any targets. This PR add that a non empty button title is also required.
#587 