### PR TITLE
Update minimum deployment target to iOS 9.0 and minor version bump

### DIFF
--- a/MBProgressHUD.podspec
+++ b/MBProgressHUD.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MBProgressHUD"
-  s.version      = "1.3.0"
+  s.version      = "1.2.0"
   s.summary      = "An iOS activity indicator view."
   s.description  = <<-DESC
                     MBProgressHUD is an iOS drop-in class that displays a translucent HUD

--- a/MBProgressHUD.podspec
+++ b/MBProgressHUD.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MBProgressHUD"
-  s.version      = "1.2.0"
+  s.version      = "1.3.0"
   s.summary      = "An iOS activity indicator view."
   s.description  = <<-DESC
                     MBProgressHUD is an iOS drop-in class that displays a translucent HUD
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { 'Matej Bukovinski' => 'matej@bukovinski.com' }
   s.source       = { :git => "https://github.com/matej/MBProgressHUD.git", :tag => s.version.to_s }
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.source_files = '*.{h,m}'
   s.frameworks   = "CoreGraphics", "QuartzCore"


### PR DESCRIPTION
Expands upon #608 by making sure the Cocoapods system recognizes the minimum target. 

Xcode 12 no longer supports iOS 8 and throws warnings if any frameworks use a lower minimum deployment target. This PR updates the deployment target in the podspec. I didn't see any other places it needs to be updated but am happy to update other locations if they exist.

I've included a minor version bump in the podspec since this is a semi-breaking change as it will no longer support anyone who is developing for iOS 8 - although since Apple doesn't support that type of development anyway it seems unlikely and therefore not worthy of a major bump.