### PR TITLE
Fix UIKit import issue while using MBProgressHUD framewok in Package …

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -27,8 +27,9 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 #import <CoreGraphics/CoreGraphics.h>
+#if __has_include(<UIKit/UIKit.h>)
+#import <UIKit/UIKit.h>
 
 @class MBBackgroundView;
 @protocol MBProgressHUDDelegate;
@@ -409,3 +410,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -15,7 +15,7 @@ static const CGFloat MBDefaultPadding = 4.f;
 static const CGFloat MBDefaultLabelFontSize = 16.f;
 static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 
-
+#if __has_include(<UIKit/UIKit.h>)
 @interface MBProgressHUD ()
 
 @property (nonatomic, assign) BOOL useAnimation;
@@ -1192,3 +1192,4 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 }
 
 @end
+#endif


### PR DESCRIPTION
I am using MBProgressHUD in one of my framework. 
This framework has Swift.package file which has MBProgressHUD

**.package(name: "MBProgressHUD", url: "https://github.com/jdg/MBProgressHUD.git", from: "1.2.0")**

When I try to build or test my framework using command **swift build** & **swift test** Getting below error.

<img width="1330" alt="Screen Shot 2021-08-21 at 11 46 42 PM" src="https://user-images.githubusercontent.com/5119513/130331500-255e4416-eed7-4602-b570-2d623353ef30.png">

I have verified after these changes both swift build & swift test working fine.
