### PR TITLE
Fixed crash caused by continuous calls to "setCustomView:" method

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -589,7 +589,8 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
         }
     }];
 
-    [bezel addConstraints:bezelConstraints];
+//    [bezel addConstraints:bezelConstraints];
+    [NSLayoutConstraint activateConstraints:bezelConstraints];
     self.bezelConstraints = bezelConstraints;
 
     self.paddingConstraints = [paddingConstraints copy];


### PR DESCRIPTION
    UIImage *img = [UIImage imageNamed:@"hub_warning_icon"];
    UIImageView *customView = [[UIImageView alloc] initWithImage:img];
    for (NSUInteger i = 0; i < 2; i++) {
        
        MBProgressHUD *hud = [self toastToView:self.view];
        hud.mode = MBProgressHUDModeCustomView;
        [hud setCustomView:customView];
        hud.label.text = @"Title";
        hud.detailsLabel.text = @"Content";
        [hud hideAnimated:YES afterDelay:2];
    }

**The above code will crash, and the log is as follows:**

Thread 1: "Unable to install constraint on view.  Does the constraint reference something from outside the subtree of the view?  That's illegal. constraint:<NSLayoutConstraint:0x600003178870 UIImageView:0x151007950.centerX == MBBackgroundView:0x14fe48390.centerX   (active)> view:<MBBackgroundView: 0x14fe48390; frame = (0 0; 0 0); clipsToBounds = YES; animations = { opacity=<CASpringAnimation: 0x600001258160>; }; layer = <CALayer: 0x600001260c60>>"