### PR TITLE
Displaying localizedDescription and localizedAdditionalDescription of the progressObject.

### DIFF
--- a/Demo/HudDemo/MBHudDemoViewController.m
+++ b/Demo/HudDemo/MBHudDemoViewController.m
@@ -315,6 +315,7 @@
 }
 
 - (void)doSomeWorkWithProgressObject:(NSProgress *)progressObject {
+    progressObject.localizedDescription = @"Download Progress";
 	// This just increases the progress indicator in a loop.
 	while (progressObject.fractionCompleted < 1.0f) {
 		if (progressObject.isCancelled) break;

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -734,6 +734,8 @@ static const CGFloat MBDefaultDetailsLabelFontSize = 12.f;
 
 - (void)updateProgressFromProgressObject {
     self.progress = self.progressObject.fractionCompleted;
+    self.label.text = self.progressObject.localizedDescription;
+    self.detailsLabel.text = self.progressObject.localizedAdditionalDescription;
 }
 
 #pragma mark - Notifications


### PR DESCRIPTION
This PR does just that.
label.text and detailLabel.text takes their info from the progressObject. They can be customized or use the default text. To suppress one (or both) of the labels, set the descriptions to empty strings.