### PR TITLE
#647: Adds Privacy Manifest as Package.swift resource

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
             path: ".",
             exclude: ["Demo"],
             sources: ["MBProgressHUD.h", "MBProgressHUD.m"],
+            resources: [.copy("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "include"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
As requested in #647 - the manifest file should be referenced in resources definition in Package.swift file. 